### PR TITLE
Apply Kubernetes pod labels to Prometheus labels

### DIFF
--- a/rucio-ams/docker/prometheus/prometheus.yml
+++ b/rucio-ams/docker/prometheus/prometheus.yml
@@ -62,6 +62,8 @@ scrape_configs:
         - role: "pod"
           label: "app=rucio-server"
     relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
       - source_labels: [__address__]
         action: replace
         regex: ([^:]+):.*
@@ -83,6 +85,8 @@ scrape_configs:
         - role: "pod"
           label: "app=rucio-server-auth"
     relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
       - source_labels: [__address__]
         action: replace
         regex: ([^:]+):.*
@@ -104,6 +108,11 @@ scrape_configs:
         - role: "pod"
           label: "app-group=rucio-daemons"
     relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: drop
+        regex: .+abacus.+
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
       - source_labels: [__address__]
         action: replace
         regex: ([^:]+):.*


### PR DESCRIPTION
Removed `rucio-ui` and `abacus-*` daemon pods from being scraped.