### PR TITLE
Brought helm-charts to latest release-1.29-LTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ In particular please make sure that the following are set by the sourcing of the
 Source the setup_rucio_env.sh file at the top of the target experiment's configuration tree to configure the environment.
 Use deploy-rucio.sh to deploy services onto the OKD cluster after the environment is configured appropriately as described above.
 Use undeploy-rucio.sh to remove everything (Services, Pods, Routes, Persistent Volumes and Claims, etc..).
+Use update_cert_secrets.sh to re-apply certificate secrets. Remember to `kubectl rollout restart deployment` to restart all deployments so that new pods will use the updated secrets.
 
 The Rucio source code may be patched when the images are built by placing patch files into one of two locations: $RUCIO_AMS_DIR/rucio-ams/docker/[server,daemon]/patches
 

--- a/rucio-ams/helm/helm_scripts/update_cert_secrets.sh
+++ b/rucio-ams/helm/helm_scripts/update_cert_secrets.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+####
+# Run this in order to update secrets for use by the Openshift deployment. Secret names are referred to by the Helm templates.
+####
+
+# Server
+kubectl create secret generic rucio-$EXPERIMENT-server-hostcert \
+	--from-file=hostcert.pem=$RUCIO_AMS_DIR/$EXPERIMENT/certs/$AMS_RUCIO_CERT \
+        --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl create secret generic rucio-$EXPERIMENT-server-hostkey \
+	--from-file=hostkey.pem=$RUCIO_AMS_DIR/$EXPERIMENT/certs/$AMS_RUCIO_KEY \
+        --dry-run=client -o yaml | kubectl apply -f -
+
+#kubectl create secret generic rucio-$EXPERIMENT-server-cafile \
+#        --from-file=ca.pem=$RUCIO_AMS_DIR/$EXPERIMENT/certs/$AMS_RUCIO_CA_BUNDLE
+#
+# Auth Server
+
+kubectl create secret generic rucio-$EXPERIMENT-auth-hostcert \
+	--from-file=hostcert.pem=$RUCIO_AMS_DIR/$EXPERIMENT/certs/$AMS_RUCIO_CERT \
+        --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl create secret generic rucio-$EXPERIMENT-auth-hostkey \
+	--from-file=hostkey.pem=$RUCIO_AMS_DIR/$EXPERIMENT/certs/$AMS_RUCIO_KEY \
+        --dry-run=client -o yaml | kubectl apply -f -
+
+#kubectl create secret generic rucio-$EXPERIMENT-auth-cafile \
+#        --from-file=ca.pem=$RUCIO_AMS_DIR/$EXPERIMENT/certs/$AMS_RUCIO_CA_BUNDLE
+
+
+# Daemons
+kubectl create secret generic rucio-$EXPERIMENT-rucio-x509up \
+        --from-file=hostcert.pem=$RUCIO_AMS_DIR/$EXPERIMENT/certs/$AMS_RUCIO_CERT \
+        --from-file=hostkey.pem=$RUCIO_AMS_DIR/$EXPERIMENT/certs/$AMS_RUCIO_KEY \
+        --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl create secret generic rucio-$EXPERIMENT-fts-cert \
+        --from-file=usercert.pem=$RUCIO_AMS_DIR/$EXPERIMENT/certs/$AMS_RUCIO_CERT \
+        --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl create secret generic rucio-$EXPERIMENT-fts-key \
+        --from-file=new_userkey.pem=$RUCIO_AMS_DIR/$EXPERIMENT/certs/$AMS_RUCIO_KEY \
+        --dry-run=client -o yaml | kubectl apply -f -
+
+#kubectl create secret generic rucio-$EXPERIMENT-rucio-ca-bundle \
+#        --from-file=ca.pem=$RUCIO_AMS_DIR/$EXPERIMENT/certs/$AMS_RUCIO_CA_BUNDLE
+
+# Reapers need the whole directory of certificates
+#mkdir /tmp/reaper-certs
+#cp /etc/grid-security/certificates/*.0 /tmp/reaper-certs/
+#cp /etc/grid-security/certificates/*.signing_policy /tmp/reaper-certs/
+#kubectl create secret generic rucio-$EXPERIMENT-rucio-ca-bundle-reaper \
+#        --from-file=/tmp/reaper-certs
+#rm -r /tmp/reaper-certs
+
+# Hermes
+kubectl create secret generic rucio-$EXPERIMENT-hermes-cert \
+        --from-file=usercert.pem=$RUCIO_AMS_DIR/$EXPERIMENT/certs/$AMS_RUCIO_CERT \
+        --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl create secret generic rucio-$EXPERIMENT-hermes-key \
+        --from-file=new_userkey.pem=$RUCIO_AMS_DIR/$EXPERIMENT/certs/$AMS_RUCIO_KEY \
+        --dry-run=client -o yaml | kubectl apply -f -
+
+# WebUI
+kubectl create secret generic rucio-$EXPERIMENT-hostcert \
+	--from-file=hostcert.pem=$RUCIO_AMS_DIR/$EXPERIMENT/certs/$AMS_RUCIO_CERT \
+        --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl create secret generic rucio-$EXPERIMENT-hostkey \
+	--from-file=hostkey.pem=$RUCIO_AMS_DIR/$EXPERIMENT/certs/$AMS_RUCIO_KEY \
+        --dry-run=client -o yaml | kubectl apply -f -
+
+#kubectl create secret generic rucio-$EXPERIMENT-cafile \
+#        --from-file=ca.pem=$RUCIO_AMS_DIR/$EXPERIMENT/certs/$AMS_RUCIO_CA_BUNDLE
+#
+# Messenger
+kubectl create secret generic ssl-secrets \
+	--from-file=hostcert.pem=$RUCIO_AMS_DIR/$EXPERIMENT/certs/$AMS_RUCIO_CERT \
+	--from-file=hostkey.pem=$RUCIO_AMS_DIR/$EXPERIMENT/certs/$AMS_RUCIO_KEY \
+	--from-file=ca.pem=$RUCIO_AMS_DIR/$EXPERIMENT/certs/$AMS_RUCIO_CA_BUNDLE \
+        --dry-run=client -o yaml | kubectl apply -f -
+
+# Replica Recoverer
+#kubectl create secret generic rucio-$EXPERIMENT-suspicious-replica-recoverer-input \
+#	--from-file=suspicious_replica_recoverer.json=$RUCIO_AMS_DIR/$EXPERIMENT/suspicious_replica_recoverer.json
+
+# Automatix
+#kubectl create secret generic rucio-$EXPERIMENT-automatix-input \
+#	--from-file=automatix.json=$RUCIO_AMS_DIR/$EXPERIMENT/automatix.json

--- a/rucio-env
+++ b/rucio-env
@@ -23,6 +23,12 @@ deactivate () {
         unset -f deactivate
     fi
 
+    if [ -n "${_OLD_PATH:-}" ] ; then
+        PATH="${_OLD_PATH:-}"
+        export PATH
+        unset _OLD_PATH
+    fi
+
 }
 
 set_ps1 () {
@@ -70,6 +76,8 @@ echo Rucio Version: $RUCIO_AMS_VERSION
 echo Docker Tag: $RUCIO_AMS_VERSION_TAG
 
 # add bin to the PATH
+_OLD_PATH="${PATH:-}"
+export _OLD_PATH
 export PATH=$RUCIO_AMS_DIR/bin:$PATH
 
 set_ps1


### PR DESCRIPTION
Running `deactivate` in the environment will return $PATH to what it was previously.