### PR TITLE
Enabled rucio-ui, rucio-messenger, hermes, and cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ exporter.yaml
 autotransfer.yaml
 prometheus.yaml
 
+!overlays/*/**
+
 # Ignore hard links that make the Fermilab policy package available inside the Docker build contexts.
 rucio-ams/docker/permissions-fnal/mu2e/
 rucio-ams/docker/permissions-fnal/dune/

--- a/overlays/int/Makefile
+++ b/overlays/int/Makefile
@@ -1,6 +1,6 @@
 EXPERIMENT=int
 SERVER_CHART_VERSION := 32.0.0
-DAEMON_CHART_VERSION := 32.0.0
+DAEMON_CHART_VERSION := 32.0.2
 UI_CHART_VERSION := 32.0.0
 
 helm:
@@ -14,18 +14,17 @@ rucio-daemons: helm
 	helm template fnal rucio/rucio-daemons --version=${DAEMON_CHART_VERSION} --values=rucio/values-rucio-daemons.yaml > rucio/helm-rucio-daemons.yaml
 
 rucio-ui: helm
-	helm template fnal rucio/rucio-ui --version=${UI_CHART_VERSION} --values=rucio/values-rucio-ui.yaml > rucio/helm-rucio-ui.yaml
+	helm template fnal rucio/rucio-ui --version=${UI_CHART_VERSION} --values=rucio/values-rucio-ui.yaml --debug > rucio/helm-rucio-ui.yaml
 
-#rucio: rucio-server rucio-daemons rucio-ui
-rucio: rucio-server rucio-daemons
+rucio: rucio-server rucio-daemons rucio-ui
 
-#get-secrets:
-	#mkdir -p rucio/etc/.secrets
-	#vault kv get --field=${EXPERIMENT}-server-hostkey secret/rucio/${EXPERIMENT}-rucio/rucio  > rucio/etc/.secrets/hostkey.pem
-	#vault kv get --field=${EXPERIMENT}-server-hostcert secret/rucio/${EXPERIMENT}-rucio/rucio  > rucio/etc/.secrets/hostcert.pem
-	#vault kv get --field=${EXPERIMENT}-server-cafile secret/rucio/${EXPERIMENT}-rucio/rucio  > rucio/etc/.secrets/ca.pem
-	#vault kv get --field=${EXPERIMENT}-db-conn-str secret/rucio/${EXPERIMENT}-rucio/rucio  > rucio/etc/.secrets/db-conn-str.txt
-	#curl https://raw.githubusercontent.com/rucio/rucio/master/etc/automatix.json > rucio/etc/.secrets/automatix.json
+# get-secrets:
+# 	mkdir -p rucio/etc/.secrets
+# 	vault kv get --field=${EXPERIMENT}-server-hostkey secret/rucio/${EXPERIMENT}-rucio/rucio  > rucio/etc/.secrets/hostkey.pem
+# 	vault kv get --field=${EXPERIMENT}-server-hostcert secret/rucio/${EXPERIMENT}-rucio/rucio  > rucio/etc/.secrets/hostcert.pem
+# 	vault kv get --field=${EXPERIMENT}-server-cafile secret/rucio/${EXPERIMENT}-rucio/rucio  > rucio/etc/.secrets/ca.pem
+# 	vault kv get --field=${EXPERIMENT}-db-conn-str secret/rucio/${EXPERIMENT}-rucio/rucio  > rucio/etc/.secrets/db-conn-str.txt
+# 	curl https://raw.githubusercontent.com/rucio/rucio/master/etc/automatix.json > rucio/etc/.secrets/automatix.json
 
 #clean-secrets:
 #	rm -rf rucio/etc/.secrets

--- a/overlays/int/rucio/cache.yaml
+++ b/overlays/int/rucio/cache.yaml
@@ -1,0 +1,49 @@
+---
+# Source: rucio-cache/templates/cache_service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: rucio-cache
+  labels:
+    app: rucio-cache
+    chart: rucio-cache-0.3.0
+    release: rucio-int-cache
+    heritage: Helm
+spec:
+  type: ClusterIP 
+  ports:
+    - port: 11211
+      targetPort: 11211
+      protocol: TCP
+      name: https
+  selector:
+    app: rucio-cache
+    release: rucio-int-cache
+---
+# Source: rucio-cache/templates/cache_deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rucio-int-cache
+  labels:
+    app: rucio-cache
+    chart: rucio-cache-0.3.0
+    release: rucio-int-cache
+    heritage: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rucio-cache
+      release: rucio-int-cache
+  template:
+    metadata:
+      labels:
+        app: rucio-cache
+        release: rucio-int-cache
+    spec:
+      serviceAccountName: useroot
+      containers:
+        - name: rucio-cache
+          image: "imageregistry.fnal.gov/rucio-ams/rucio-ams-cache:1.29.12"
+          imagePullPolicy: Always

--- a/overlays/int/rucio/etc/.gitignore
+++ b/overlays/int/rucio/etc/.gitignore
@@ -1,0 +1,1 @@
+.secrets

--- a/overlays/int/rucio/etc/enabled_plugins
+++ b/overlays/int/rucio/etc/enabled_plugins
@@ -1,0 +1,1 @@
+[rabbitmq_prometheus,rabbitmq_stomp].

--- a/overlays/int/rucio/etc/hermes_patch_20231027.py
+++ b/overlays/int/rucio/etc/hermes_patch_20231027.py
@@ -1,0 +1,742 @@
+# -*- coding: utf-8 -*-
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# 20231027: Patch to fix ssl connection by Dennis Lee
+
+"""
+   Hermes is a daemon that get the messages and sends them to external services (influxDB, ES, ActiveMQ).
+"""
+
+import calendar
+import datetime
+import functools
+import json
+import logging
+import random
+import re
+import smtplib
+import socket
+import sys
+import threading
+import time
+from configparser import NoOptionError, NoSectionError
+from email.mime.text import MIMEText
+from typing import TYPE_CHECKING
+
+import requests
+import stomp
+
+import rucio.db.sqla.util
+from rucio.common.config import (
+    config_get,
+    config_get_bool,
+    config_get_int,
+    config_get_list,
+)
+from rucio.common.exception import DatabaseException
+from rucio.common.logging import setup_logging
+from rucio.core.message import delete_messages, retrieve_messages
+from rucio.core.monitor import MetricManager
+from rucio.daemons.common import run_daemon
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from types import FrameType
+    from typing import Optional
+
+    from rucio.daemons.common import HeartbeatHandler
+
+logging.getLogger("requests").setLevel(logging.CRITICAL)
+
+METRICS = MetricManager(module=__name__)
+graceful_stop = threading.Event()
+DAEMON_NAME = "hermes"
+
+RECONNECT_COUNTER = METRICS.counter(
+    name="reconnect.{host}",
+    documentation="Counts Hermes reconnects to different ActiveMQ brokers",
+    labelnames=("host",),
+)
+
+
+def default(datetype):
+    if isinstance(datetype, (datetime.date, datetime.datetime)):
+        return datetype.isoformat()
+
+
+class HermesListener(stomp.ConnectionListener):
+    """
+    Hermes Listener
+    """
+
+    def __init__(self, broker):
+        """
+        __init__
+        """
+        self.__broker = broker
+
+    def on_error(self, frame):
+        """
+        Error handler
+        """
+        logging.error("[broker] [%s]: %s", self.__broker, frame.body)
+
+
+def setup_activemq(logger: "Callable"):
+    """
+    Deliver messages to ActiveMQ
+
+    :param logger:             The logger object.
+    """
+
+    logger(logging.INFO, "[broker] Resolving brokers")
+
+    brokers_alias = []
+    brokers_resolved = []
+    try:
+        brokers_alias = [
+            broker.strip()
+            for broker in config_get("messaging-hermes", "brokers").split(",")
+        ]
+    except:
+        raise Exception("Could not load brokers from configuration")
+
+    logger(logging.INFO, "[broker] Resolving broker dns alias: %s", brokers_alias)
+    brokers_resolved = []
+    for broker in brokers_alias:
+        try:
+            addrinfos = socket.getaddrinfo(
+                broker, 0, socket.AF_INET, 0, socket.IPPROTO_TCP
+            )
+            brokers_resolved.extend(ai[4][0] for ai in addrinfos)
+        except socket.gaierror as ex:
+            logger(
+                logging.ERROR,
+                "[broker] Cannot resolve domain name %s (%s)",
+                broker,
+                str(ex),
+            )
+
+    logger(logging.DEBUG, "[broker] Brokers resolved to %s", brokers_resolved)
+
+    if not brokers_resolved:
+        logger(logging.FATAL, "[broker] No brokers resolved.")
+        return None, None, None, None, None
+
+    broker_timeout = 3
+    if not broker_timeout:  # Allow zero in config
+        broker_timeout = None
+
+    logger(logging.INFO, "[broker] Checking authentication method")
+    use_ssl = True
+    try:
+        use_ssl = config_get_bool("messaging-hermes", "use_ssl")
+    except:
+        logger(
+            logging.INFO,
+            "[broker] Could not find use_ssl in configuration -- please update your rucio.cfg",
+        )
+
+    port = config_get_int("messaging-hermes", "port")
+    vhost = config_get("messaging-hermes", "broker_virtual_host", raise_exception=False)
+    username = None
+    password = None
+    if not use_ssl:
+        username = config_get("messaging-hermes", "username")
+        password = config_get("messaging-hermes", "password")
+        port = config_get_int("messaging-hermes", "nonssl_port")
+
+    conns = []
+    for broker in brokers_resolved:
+        if not use_ssl:
+            logger(
+                logging.INFO,
+                "[broker] setting up username/password authentication: %s",
+                broker,
+            )
+        else:
+            logger(
+                logging.INFO,
+                "[broker] setting up ssl cert/key authentication: %s",
+                broker,
+            )
+
+        con = stomp.Connection12(
+            host_and_ports=[(broker, port)],
+            vhost=vhost,
+            keepalive=True,
+            timeout=broker_timeout,
+        )
+        if use_ssl:
+            con.set_ssl(
+                key_file=config_get("messaging-hermes", "ssl_key_file"),
+                cert_file=config_get("messaging-hermes", "ssl_cert_file"),
+            )
+
+        con.set_listener(
+            "rucio-hermes", HermesListener(con.transport._Transport__host_and_ports[0])
+        )
+
+        conns.append(con)
+    destination = config_get("messaging-hermes", "destination")
+    return conns, destination, username, password, use_ssl
+
+
+def deliver_to_activemq(
+    messages, conns, destination, username, password, use_ssl, logger
+):
+    """
+    Deliver messages to ActiveMQ
+
+    :param messages:           The list of messages.
+    :param conns:              A list of connections.
+    :param destination:        The destination topic or queue.
+    :param username:           The username if no SSL connection.
+    :param password:           The username if no SSL connection.
+    :param use_ssl:            Boolean to choose if SSL connection is used.
+    :param logger:             The logger object.
+
+    :returns:                  List of message_id to delete
+    """
+    to_delete = []
+    for message in messages:
+        try:
+            conn = random.sample(conns, 1)[0]
+            if not conn.is_connected():
+                host_and_ports = conn.transport._Transport__host_and_ports[0][0]
+                RECONNECT_COUNTER.labels(host=host_and_ports.split(".")[0]).inc()
+                if not use_ssl:
+                    logger(
+                        logging.INFO,
+                        "[broker] - connecting with USERPASS to %s",
+                        host_and_ports,
+                    )
+                    conn.connect(username, password, wait=True)
+                else:
+                    logger(
+                        logging.INFO,
+                        "[broker] - connecting with SSL to %s",
+                        host_and_ports,
+                    )
+                    conn.connect(wait=True)
+
+            conn.send(
+                body=json.dumps(
+                    {
+                        "event_type": str(message["event_type"]).lower(),
+                        "payload": message["payload"],
+                        "created_at": str(message["created_at"]),
+                    }
+                ),
+                destination=destination,
+                headers={
+                    "persistent": "true",
+                    "event_type": str(message["event_type"]).lower(),
+                },
+            )
+
+            to_delete.append(message["id"])
+        except ValueError:
+            logger(
+                logging.ERROR,
+                "[broker] Cannot serialize payload to JSON: %s",
+                str(message["payload"]),
+            )
+            to_delete.append(message["id"])
+            continue
+        except stomp.exception.NotConnectedException as error:
+            logger(
+                logging.WARNING,
+                "[broker] Could not deliver message due to NotConnectedException: %s",
+                str(error),
+            )
+            continue
+        except stomp.exception.ConnectFailedException as error:
+            logger(
+                logging.WARNING,
+                "[broker] Could not deliver message due to ConnectFailedException: %s",
+                str(error),
+            )
+            continue
+        except Exception as error:
+            logger(logging.ERROR, "[broker] Could not deliver message: %s", str(error))
+            continue
+
+        if str(message["event_type"]).lower().startswith("transfer") or str(
+            message["event_type"]
+        ).lower().startswith("stagein"):
+            logger(
+                logging.DEBUG,
+                "[broker] - event_type: %s, scope: %s, name: %s, rse: %s, request-id: %s, transfer-id: %s, created_at: %s",
+                str(message["event_type"]).lower(),
+                message["payload"].get("scope", None),
+                message["payload"].get("name", None),
+                message["payload"].get("dst-rse", None),
+                message["payload"].get("request-id", None),
+                message["payload"].get("transfer-id", None),
+                str(message["created_at"]),
+            )
+
+        elif str(message["event_type"]).lower().startswith("dataset"):
+            logger(
+                logging.DEBUG,
+                "[broker] - event_type: %s, scope: %s, name: %s, rse: %s, rule-id: %s, created_at: %s)",
+                str(message["event_type"]).lower(),
+                message["payload"].get("scope", None),
+                message["payload"].get("name", None),
+                message["payload"].get("rse", None),
+                message["payload"].get("rule_id", None),
+                str(message["created_at"]),
+            )
+
+        elif str(message["event_type"]).lower().startswith("deletion"):
+            if "url" not in message["payload"]:
+                message["payload"]["url"] = "unknown"
+            logger(
+                logging.DEBUG,
+                "[broker] - event_type: %s, scope: %s, name: %s, rse: %s, url: %s, created_at: %s)",
+                str(message["event_type"]).lower(),
+                message["payload"].get("scope", None),
+                message["payload"].get("name", None),
+                message["payload"].get("rse", None),
+                message["payload"].get("url", None),
+                str(message["created_at"]),
+            )
+        else:
+            logger(logging.DEBUG, "[broker] Other message: %s", message)
+    return to_delete
+
+
+def deliver_emails(messages: list[dict], logger: "Callable") -> list:
+    """
+    Sends emails
+
+    :param messages:           The list of messages.
+    :param logger:             The logger object.
+
+    :returns:                  List of message_id to delete
+    """
+
+    email_from = config_get("messaging-hermes", "email_from")
+    send_email = config_get_bool(
+        "messaging-hermes", "send_email", raise_exception=False, default=True
+    )
+    to_delete = []
+    for message in messages:
+        if message['event_type'] == 'email':
+            msg = MIMEText(message['payload']['body'])
+            msg['From'] = email_from
+            msg['To'] = ', '.join(message['payload']['to'])
+            msg['Subject'] = message['payload']['subject']
+
+            try:
+                if send_email:
+                    smtp = smtplib.SMTP()
+                    smtp.connect()
+                    smtp.sendmail(
+                        msg["From"], message["payload"]["to"], msg.as_string()
+                    )
+                    smtp.quit()
+                to_delete.append(message["id"])
+            except Exception as error:
+                logger(logging.ERROR, "Cannot send email : %s", str(error))
+        else:
+            to_delete.append(message["id"])
+            continue
+    return to_delete
+
+
+def submit_to_elastic(messages: list[dict], endpoint: str, logger: "Callable") -> int:
+    """
+    Aggregate a list of message to ElasticSearch
+
+    :param messages:           The list of messages.
+    :param endpoint:           The ES endpoint were to send the messages.
+    :param logger:             The logger object.
+
+    :returns:                  HTTP status code. 200 and 204 OK. Rest is failure.
+    """
+    text = ""
+    for message in messages:
+        text += '{ "index":{ } }\n%s\n' % json.dumps(message, default=default)
+    res = requests.post(
+        endpoint, data=text, headers={"Content-Type": "application/json"}
+    )
+    return res.status_code
+
+
+def aggregate_to_influx(
+    messages: list[dict], bin_size: int, endpoint: str, logger: "Callable"
+) -> int:
+    """
+    Aggregate a list of message using a certain bin_size
+    and submit them to a InfluxDB endpoint
+
+    :param messages:           The list of messages.
+    :param bin_size:           The size of the bins for the aggreagation (e.g. 10m, 1h, etc.).
+    :param endpoint:           The InfluxDB endpoint were to send the messages.
+    :param logger:             The logger object.
+
+    :returns:                  HTTP status code. 200 and 204 OK. Rest is failure.
+    """
+    bins = {}
+    dtime = datetime.datetime.now()
+    microsecond = dtime.microsecond
+
+    for message in messages:
+        event_type = message["event_type"]
+        payload = message["payload"]
+        if event_type in ["transfer-failed", "transfer-done"]:
+            if not payload["transferred_at"]:
+                logger(
+                    logging.WARNING,
+                    "No transferred_at for message. Reason : %s",
+                    payload["reason"],
+                )
+                continue
+            transferred_at = time.strptime(
+                payload["transferred_at"], "%Y-%m-%d %H:%M:%S"
+            )
+            if bin_size == "1m":
+                transferred_at = int(calendar.timegm(transferred_at)) * 1000000000
+                transferred_at += microsecond
+            if transferred_at not in bins:
+                bins[transferred_at] = {}
+            src_rse, dest_rse, activity = (
+                payload["src-rse"],
+                payload["dst-rse"],
+                payload["activity"],
+            )
+            activity = re.sub(" ", r"\ ", activity)
+            key = "transfer,activity=%s,src_rse=%s,dst_rse=%s" % (
+                activity,
+                src_rse,
+                dest_rse,
+            )
+            if key not in bins[transferred_at]:
+                bins[transferred_at][key] = [0, 0, 0, 0]
+            if event_type == "transfer-done":
+                bins[transferred_at][key][0] += 1
+                bins[transferred_at][key][1] += payload["bytes"]
+            if event_type == "transfer-failed":
+                bins[transferred_at][key][2] += 1
+                bins[transferred_at][key][3] += payload["bytes"]
+        elif event_type in ["deletion-failed", "deletion-done"]:
+            created_at = message["created_at"]
+            if bin_size == "1m":
+                created_at = created_at.replace(
+                    second=0, microsecond=0, tzinfo=datetime.timezone.utc
+                ).timestamp()
+            created_at = int(created_at) * 1000000000
+            created_at += microsecond
+            if created_at not in bins:
+                bins[created_at] = {}
+            rse = payload["rse"]
+            key = "deletion,rse=%s" % (rse)
+            if key not in bins[created_at]:
+                bins[created_at][key] = [0, 0, 0, 0]
+            if event_type == "deletion-done":
+                bins[created_at][key][0] += 1
+                bins[created_at][key][1] += payload["bytes"]
+            if event_type == "deletion-failed":
+                bins[created_at][key][2] += 1
+                bins[created_at][key][3] += payload["bytes"]
+    points = ""
+    for timestamp in bins:
+        for entry in bins[timestamp]:
+            metrics = bins[timestamp][entry]
+            event_type = entry.split(",")[0]
+            point = (
+                "%s nb_%s_done=%s,bytes_%s_done=%s,nb_%s_failed=%s,bytes_%s_failed=%s %s"
+                % (
+                    entry,
+                    event_type,
+                    metrics[0],
+                    event_type,
+                    metrics[1],
+                    event_type,
+                    metrics[2],
+                    event_type,
+                    metrics[3],
+                    timestamp,
+                )
+            )
+            points += point
+            points += "\n"
+    influx_token = config_get("hermes", "influxdb_token", False, None)
+    if influx_token:
+        headers = {"Authorization": "Token %s" % influx_token}
+    if points:
+        res = requests.post(endpoint, headers=headers, data=points)
+        logger(logging.DEBUG, "%s", str(res.text))
+        return res.status_code
+    return 204
+
+
+def hermes(once: bool = False, bulk: int = 1000, sleep_time: int = 10) -> None:
+    """
+    Creates a Hermes Worker that can submit messages to different services (InfluXDB, ElasticSearch, ActiveMQ)
+    The list of services need to be define in the config service in the hermes section.
+    The list of endpoints need to be defined in rucio.cfg in the hermes section.
+
+    :param once:       Run only once.
+    :param bulk:       The number of requests to process.
+    :param sleep_time: Time between two cycles.
+    """
+    run_daemon(
+        once=once,
+        graceful_stop=graceful_stop,
+        executable=DAEMON_NAME,
+        partition_wait_time=1,
+        sleep_time=sleep_time,
+        run_once_fnc=functools.partial(
+            run_once,
+            bulk=bulk,
+        ),
+    )
+
+
+def run_once(heartbeat_handler: "HeartbeatHandler", bulk: int, **_kwargs) -> bool:
+
+    worker_number, total_workers, logger = heartbeat_handler.live()
+    try:
+        services_list = config_get_list("hermes", "services_list")
+    except (NoOptionError, NoSectionError, RuntimeError):
+        logger(logging.DEBUG, "No services found, exiting")
+        sys.exit(1)
+
+    if "influx" in services_list:
+        influx_endpoint = None
+        try:
+            influx_endpoint = config_get("hermes", "influxdb_endpoint", False, None)
+            if not influx_endpoint:
+                logger(
+                    logging.ERROR,
+                    "InfluxDB defined in the services list, but no endpoint can be found",
+                )
+        except Exception as err:
+            logger(logging.ERROR, str(err))
+    if "elastic" in services_list:
+        elastic_endpoint = None
+        try:
+            elastic_endpoint = config_get("hermes", "elastic_endpoint", False, None)
+            if not elastic_endpoint:
+                logger(
+                    logging.ERROR,
+                    "Elastic defined in the services list, but no endpoint can be found",
+                )
+        except Exception as err:
+            logger(logging.ERROR, str(err))
+    conns = None
+    if "activemq" in services_list:
+        try:
+            conns, destination, username, password, use_ssl = setup_activemq(logger)
+            if not conns:
+                logger(
+                    logging.ERROR,
+                    "ActiveMQ defined in the services list, cannot be setup",
+                )
+        except Exception as err:
+            logger(logging.ERROR, str(err))
+
+    worker_number, total_workers, logger = heartbeat_handler.live()
+    message_dict = {}
+    message_ids = []
+    start_time = time.time()
+    messages = retrieve_messages(
+        bulk=bulk,
+        old_mode=False,
+        thread=worker_number,
+        total_threads=total_workers,
+    )
+
+    to_delete = []
+    if messages:
+        for message in messages:
+            service = message["services"]
+            if service not in message_dict:
+                message_dict[service] = []
+            message_dict[service].append(message)
+            message_ids.append(message["id"])
+        logger(
+            logging.DEBUG,
+            "Retrieved %i messages retrieved in %s seconds",
+            len(messages),
+            time.time() - start_time,
+        )
+
+        if "influx" in message_dict and influx_endpoint:
+            # For influxDB, bulk submission, either everything succeeds or fails
+            t_time = time.time()
+            logger(logging.DEBUG, "Will submit to influxDB")
+            try:
+                state = aggregate_to_influx(
+                    messages=message_dict["influx"],
+                    bin_size="1m",
+                    endpoint=influx_endpoint,
+                    logger=logger,
+                )
+                if state in [204, 200]:
+                    logger(
+                        logging.INFO,
+                        "%s messages successfully submitted to influxDB in %s seconds",
+                        len(message_dict["influx"]),
+                        time.time() - t_time,
+                    )
+                    for message in message_dict["influx"]:
+                        to_delete.append(message)
+                else:
+                    logger(
+                        logging.ERROR,
+                        "Failure to submit %s messages to influxDB. Returned status: %s",
+                        len(message_dict["influx"]),
+                        state,
+                    )
+            except Exception as error:
+                logger(logging.ERROR, "Error sending to InfluxDB : %s", str(error))
+
+        if "elastic" in message_dict and elastic_endpoint:
+            # For elastic, bulk submission, either everything succeeds or fails
+            t_time = time.time()
+            try:
+                state = submit_to_elastic(
+                    messages=message_dict["elastic"],
+                    endpoint=elastic_endpoint,
+                    logger=logger,
+                )
+                if state in [200, 204]:
+                    logger(
+                        logging.INFO,
+                        "%s messages successfully submitted to elastic in %s seconds",
+                        len(message_dict["elastic"]),
+                        time.time() - t_time,
+                    )
+                    for message in message_dict["elastic"]:
+                        to_delete.append(message)
+                else:
+                    logger(
+                        logging.ERROR,
+                        "Failure to submit %s messages to elastic. Returned status: %s",
+                        len(message_dict["influx"]),
+                        state,
+                    )
+            except Exception as error:
+                logger(logging.ERROR, "Error sending to Elastic : %s", str(error))
+
+        if "email" in message_dict:
+            t_time = time.time()
+            try:
+                messages_sent = deliver_emails(
+                    messages=message_dict["email"], logger=logger
+                )
+                logger(
+                    logging.INFO,
+                    "%s messages successfully submitted by emails in %s seconds",
+                    len(message_dict["email"]),
+                    time.time() - t_time,
+                )
+                for message in message_dict["email"]:
+                    if message["id"] in messages_sent:
+                        to_delete.append(message)
+            except Exception as error:
+                logger(logging.ERROR, "Error sending email : %s", str(error))
+
+        if "activemq" in message_dict and conns:
+            t_time = time.time()
+            try:
+                messages_sent = deliver_to_activemq(
+                    messages=message_dict["activemq"],
+                    conns=conns,
+                    destination=destination,
+                    username=username,
+                    password=password,
+                    use_ssl=use_ssl,
+                    logger=logger,
+                )
+                logger(
+                    logging.INFO,
+                    "%s messages successfully submitted to ActiveMQ in %s seconds",
+                    len(message_dict["activemq"]),
+                    time.time() - t_time,
+                )
+                for message in message_dict["activemq"]:
+                    if message["id"] in messages_sent:
+                        to_delete.append(message)
+            except Exception as error:
+                logger(logging.ERROR, "Error sending to ActiveMQ : %s", str(error))
+
+    logger(logging.INFO, "Deleting %s messages", len(to_delete))
+    to_delete = [
+        {
+            "id": message["id"],
+            "created_at": message["created_at"],
+            "updated_at": message["created_at"],
+            "payload": str(message["payload"]),
+            "event_type": message["event_type"],
+        }
+        for message in to_delete
+    ]
+    delete_messages(messages=to_delete)
+    must_sleep = True
+    return must_sleep
+
+
+def stop(signum: "Optional[int]" = None, frame: "Optional[FrameType]" = None) -> None:
+    """
+    Graceful exit.
+    """
+    logging.info("Caught CTRL-C - waiting for cycle to end before shutting down")
+    graceful_stop.set()
+
+
+def run(
+    once: bool = False,
+    threads: int = 1,
+    bulk: int = 1000,
+    sleep_time: int = 10,
+    broker_timeout: int = 3,
+) -> None:
+    """
+    Starts up the hermes threads.
+    """
+    setup_logging(process_name=DAEMON_NAME)
+
+    if rucio.db.sqla.util.is_old_db():
+        raise DatabaseException("Database was not updated, daemon won't start")
+
+    logging.info("starting hermes threads")
+    thread_list = [
+        threading.Thread(
+            target=hermes,
+            kwargs={
+                "once": once,
+                "bulk": bulk,
+                "sleep_time": sleep_time,
+            },
+        )
+        for _ in range(0, threads)
+    ]
+
+    for thrd in thread_list:
+        thrd.start()
+
+    logging.debug(thread_list)
+    # Interruptible joins require a timeout.
+    while thread_list:
+        thread_list = [
+            thread.join(timeout=3.14)
+            for thread in thread_list
+            if thread and thread.is_alive()
+        ]

--- a/overlays/int/rucio/etc/rabbitmq.conf
+++ b/overlays/int/rucio/etc/rabbitmq.conf
@@ -1,5 +1,5 @@
 log.console.level = debug
-loopback_users.guest = false
+loopback_users.guest = true
 ssl_options.cacertfile = /etc/rabbitmq/ssl/ca.pem
 ssl_options.certfile = /etc/rabbitmq/ssl/hostcert.pem
 ssl_options.fail_if_no_peer_cert = true
@@ -25,5 +25,5 @@ ssl_options.ciphers.4 = ECDHE-RSA-AES128-GCM-SHA256
 hipe_compile = false
 
 listeners.tcp = none
-stomp.listeners.tcp = none
+stomp.listeners.tcp.1 = 0.0.0.0:61613
 stomp.listeners.ssl.1 = 0.0.0.0:443

--- a/overlays/int/rucio/grid-certificates-patch.yaml
+++ b/overlays/int/rucio/grid-certificates-patch.yaml
@@ -50,3 +50,23 @@ spec:
          secret:
            $patch: delete
          emptyDir: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fnal-rucio-ui
+spec:
+  template:
+    spec:
+      initContainers:
+      - name: grid-certs
+        image: docker.io/bjwhitefnal/grid-security-files:32
+        command: ["/bin/bash", "-c", "chmod 755 /out/ && cp -rv --preserve=links /grid-certificates/* /out/"]
+        volumeMounts:
+        - name: ca-volume
+          mountPath: /out/
+      volumes:
+       - name: ca-volume
+         secret:
+           $patch: delete
+         emptyDir: {}

--- a/overlays/int/rucio/helm-rucio-daemons.yaml
+++ b/overlays/int/rucio/helm-rucio-daemons.yaml
@@ -12,7 +12,7 @@ metadata:
   name: fnal-rucio-daemons.config.abacus-account
   labels:
     app: rucio-daemons-abacus-account
-    chart: "rucio-daemons-32.0.0"
+    chart: "rucio-daemons-32.0.2"
     release: "fnal"
     heritage: "Helm"
 type: Opaque
@@ -26,7 +26,7 @@ metadata:
   name: fnal-rucio-daemons.config.abacus-collection-replica
   labels:
     app: rucio-daemons-abacus-collection-replica
-    chart: "rucio-daemons-32.0.0"
+    chart: "rucio-daemons-32.0.2"
     release: "fnal"
     heritage: "Helm"
 type: Opaque
@@ -40,7 +40,7 @@ metadata:
   name: fnal-rucio-daemons.config.abacus-rse
   labels:
     app: rucio-daemons-abacus-rse
-    chart: "rucio-daemons-32.0.0"
+    chart: "rucio-daemons-32.0.2"
     release: "fnal"
     heritage: "Helm"
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: fnal-rucio-daemons.config.automatix
   labels:
     app: rucio-daemons-automatix
-    chart: "rucio-daemons-32.0.0"
+    chart: "rucio-daemons-32.0.2"
     release: "fnal"
     heritage: "Helm"
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: fnal-rucio-daemons.config.conveyor-finisher
   labels:
     app: rucio-daemons-conveyor-finisher
-    chart: "rucio-daemons-32.0.0"
+    chart: "rucio-daemons-32.0.2"
     release: "fnal"
     heritage: "Helm"
 type: Opaque
@@ -82,7 +82,7 @@ metadata:
   name: fnal-rucio-daemons.config.conveyor-poller
   labels:
     app: rucio-daemons-conveyor-poller
-    chart: "rucio-daemons-32.0.0"
+    chart: "rucio-daemons-32.0.2"
     release: "fnal"
     heritage: "Helm"
 type: Opaque
@@ -96,7 +96,7 @@ metadata:
   name: fnal-rucio-daemons.config.conveyor-stager
   labels:
     app: rucio-daemons-conveyor-stager
-    chart: "rucio-daemons-32.0.0"
+    chart: "rucio-daemons-32.0.2"
     release: "fnal"
     heritage: "Helm"
 type: Opaque
@@ -110,7 +110,21 @@ metadata:
   name: fnal-rucio-daemons.config.conveyor-submitter
   labels:
     app: rucio-daemons-conveyor-submitter
-    chart: "rucio-daemons-32.0.0"
+    chart: "rucio-daemons-32.0.2"
+    release: "fnal"
+    heritage: "Helm"
+type: Opaque
+data:
+  component.json: "e30="
+---
+# Source: rucio-daemons/templates/hermes.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: fnal-rucio-daemons.config.hermes
+  labels:
+    app: rucio-daemons-hermes
+    chart: "rucio-daemons-32.0.2"
     release: "fnal"
     heritage: "Helm"
 type: Opaque
@@ -124,7 +138,7 @@ metadata:
   name: fnal-rucio-daemons.config.judge-cleaner
   labels:
     app: rucio-daemons-judge-cleaner
-    chart: "rucio-daemons-32.0.0"
+    chart: "rucio-daemons-32.0.2"
     release: "fnal"
     heritage: "Helm"
 type: Opaque
@@ -138,7 +152,7 @@ metadata:
   name: fnal-rucio-daemons.config.judge-evaluator
   labels:
     app: rucio-daemons-judge-evaluator
-    chart: "rucio-daemons-32.0.0"
+    chart: "rucio-daemons-32.0.2"
     release: "fnal"
     heritage: "Helm"
 type: Opaque
@@ -152,7 +166,7 @@ metadata:
   name: fnal-rucio-daemons.config.judge-injector
   labels:
     app: rucio-daemons-judge-injector
-    chart: "rucio-daemons-32.0.0"
+    chart: "rucio-daemons-32.0.2"
     release: "fnal"
     heritage: "Helm"
 type: Opaque
@@ -166,7 +180,7 @@ metadata:
   name: fnal-rucio-daemons.config.judge-repairer
   labels:
     app: rucio-daemons-judge-repairer
-    chart: "rucio-daemons-32.0.0"
+    chart: "rucio-daemons-32.0.2"
     release: "fnal"
     heritage: "Helm"
 type: Opaque
@@ -180,7 +194,7 @@ metadata:
   name: fnal-rucio-daemons.config.minos
   labels:
     app: rucio-daemons-minos
-    chart: "rucio-daemons-32.0.0"
+    chart: "rucio-daemons-32.0.2"
     release: "fnal"
     heritage: "Helm"
 type: Opaque
@@ -194,7 +208,7 @@ metadata:
   name: fnal-rucio-daemons.config.minos-temporary-expiration
   labels:
     app: rucio-daemons-minos-temporary-expiration
-    chart: "rucio-daemons-32.0.0"
+    chart: "rucio-daemons-32.0.2"
     release: "fnal"
     heritage: "Helm"
 type: Opaque
@@ -208,7 +222,7 @@ metadata:
   name: fnal-rucio-daemons.config.necromancer
   labels:
     app: rucio-daemons-necromancer
-    chart: "rucio-daemons-32.0.0"
+    chart: "rucio-daemons-32.0.2"
     release: "fnal"
     heritage: "Helm"
 type: Opaque
@@ -222,7 +236,7 @@ metadata:
   name: fnal-rucio-daemons.config.reaper
   labels:
     app: rucio-daemons-reaper
-    chart: "rucio-daemons-32.0.0"
+    chart: "rucio-daemons-32.0.2"
     release: "fnal"
     heritage: "Helm"
 type: Opaque
@@ -236,7 +250,7 @@ metadata:
   name: fnal-rucio-daemons.config.replica-recoverer
   labels:
     app: rucio-daemons-replica-recoverer
-    chart: "rucio-daemons-32.0.0"
+    chart: "rucio-daemons-32.0.2"
     release: "fnal"
     heritage: "Helm"
 type: Opaque
@@ -250,12 +264,12 @@ metadata:
   name: fnal-rucio-daemons.config.common
   labels:
     app: rucio-daemons
-    chart: "rucio-daemons-32.0.0"
+    chart: "rucio-daemons-32.0.2"
     release: "fnal"
     heritage: "Helm"
 type: Opaque
 data:
-  common.json: "ewogICJhdXRvbWF0aXgiOiB7CiAgICAiYWNjb3VudCI6ICJhdXRvbWF0aXgiLAogICAgImRhdGFzZXRfbGlmZXRpbWUiOiAzMCwKICAgICJyc2VzIjogIkRDQUNIRV9CSldISVRFX0VORCwgRENBQ0hFX0JKV0hJVEVfRU5EMiIsCiAgICAic2NvcGUiOiAiYXV0b21hdGl4IiwKICAgICJzZXRfbWV0YWRhdGEiOiAiVHJ1ZSIKICB9LAogICJjbGllbnQiOiB7CiAgICAiYWNjb3VudCI6ICJhdXRvbWF0aXgiLAogICAgImF1dGhfaG9zdCI6ICJodHRwczovL2ludC1ydWNpby5mbmFsLmdvdiIsCiAgICAiYXV0aF90eXBlIjogIng1MDlfcHJveHkiLAogICAgImNhX2NlcnQiOiAiL29wdC9jZXJ0cyIsCiAgICAiY2xpZW50X3g1MDlfcHJveHkiOiAiL29wdC9wcm94eS94NTA5dXAiLAogICAgImVuYWJsZV9tZXRyaWNzIjogIlRydWUiLAogICAgInByb3RvY29sX3N0YXRfcmV0cmllcyI6IDYsCiAgICAicmVxdWVzdF9yZXRyaWVzIjogMywKICAgICJydWNpb19ob3N0IjogImh0dHBzOi8vaW50LXJ1Y2lvLmZuYWwuZ292IgogIH0sCiAgImNvbnZleW9yIjogewogICAgImNhY2VydCI6ICIvb3B0L2NlcnRzL2NhLnBlbSIsCiAgICAiZnRzaG9zdHMiOiAiaHR0cHM6Ly9mdHMzLXB1YmxpYy5mbmFsLmdvdjo4NDQ2IiwKICAgICJ1c2VyY2VydCI6ICIvb3B0L3Byb3h5L3g1MDl1cCIKICB9LAogICJtZXNzYWdpbmctY2FjaGUiOiB7CiAgICAiYWNjb3VudCI6ICJtZW1jYWNoZSIsCiAgICAiYnJva2VycyI6ICJydWNpby1jYWNoZSIsCiAgICAiZGVzdGluYXRpb24iOiAiL3RvcGljL3J1Y2lvLmV2ZW50cy5pbnQiLAogICAgInBvcnQiOiAiNjExMjMiLAogICAgInZvbmFtZSI6ICJmZXJtaWxhYiIKICB9LAogICJtZXNzYWdpbmctaGVybWVzIjogewogICAgImJyb2tlcnMiOiAicnVjaW8tbWVzc2VuZ2VyIiwKICAgICJkZXN0aW5hdGlvbiI6ICIvdG9waWMvcnVjaW8uZXZlbnRzLmludCIsCiAgICAiZW1haWxfZnJvbSI6ICJSdWNpbyBcdTAwM2NhdGxhcy1hZGMtZGRtLXN1cHBvcnRAY2Vybi5jaCIsCiAgICAiZW1haWxfdGVzdCI6ICIiLAogICAgInBhc3N3b3JkIjogImd1ZXN0IiwKICAgICJwb3J0IjogIjQ0MyIsCiAgICAic3NsX2NlcnRfZmlsZSI6ICIvZXRjL2dyaWQtc2VjdXJpdHkvaG9zdGNlcnQucGVtIiwKICAgICJzc2xfa2V5X2ZpbGUiOiAiL2V0Yy9ncmlkLXNlY3VyaXR5L2hvc3RrZXkucGVtIiwKICAgICJ1c2Vfc3NsIjogIlRydWUiLAogICAgInVzZXJuYW1lIjogImd1ZXN0IiwKICAgICJ2b25hbWUiOiAiaW50IgogIH0sCiAgInBvbGljeSI6IHsKICAgICJwYWNrYWdlIjogImZlcm1pbGFiIgogIH0KfQ=="
+  common.json: "ewogICJhdXRvbWF0aXgiOiB7CiAgICAiYWNjb3VudCI6ICJhdXRvbWF0aXgiLAogICAgImRhdGFzZXRfbGlmZXRpbWUiOiAzMCwKICAgICJyc2VzIjogIkRDQUNIRV9CSldISVRFX0VORCwgRENBQ0hFX0JKV0hJVEVfRU5EMiIsCiAgICAic2NvcGUiOiAiYXV0b21hdGl4IiwKICAgICJzZXRfbWV0YWRhdGEiOiAiVHJ1ZSIKICB9LAogICJjbGllbnQiOiB7CiAgICAiYWNjb3VudCI6ICJhdXRvbWF0aXgiLAogICAgImF1dGhfaG9zdCI6ICJodHRwczovL2ludC1ydWNpby5mbmFsLmdvdiIsCiAgICAiYXV0aF90eXBlIjogIng1MDlfcHJveHkiLAogICAgImNhX2NlcnQiOiAiL29wdC9jZXJ0cyIsCiAgICAiY2xpZW50X3g1MDlfcHJveHkiOiAiL29wdC9wcm94eS94NTA5dXAiLAogICAgImVuYWJsZV9tZXRyaWNzIjogIlRydWUiLAogICAgInByb3RvY29sX3N0YXRfcmV0cmllcyI6IDYsCiAgICAicmVxdWVzdF9yZXRyaWVzIjogMywKICAgICJydWNpb19ob3N0IjogImh0dHBzOi8vaW50LXJ1Y2lvLmZuYWwuZ292IgogIH0sCiAgImNvbnZleW9yIjogewogICAgImNhY2VydCI6ICIvb3B0L2NlcnRzL2NhLnBlbSIsCiAgICAiZnRzaG9zdHMiOiAiaHR0cHM6Ly9mdHMzLXB1YmxpYy5mbmFsLmdvdjo4NDQ2IiwKICAgICJ1c2VyY2VydCI6ICIvb3B0L3Byb3h5L3g1MDl1cCIKICB9LAogICJoZXJtZXMiOiB7CiAgICAic2VydmljZXNfbGlzdCI6ICJhY3RpdmVtcSIKICB9LAogICJtZXNzYWdpbmctY2FjaGUiOiB7CiAgICAiYWNjb3VudCI6ICJtZW1jYWNoZSIsCiAgICAiYnJva2VycyI6ICJydWNpby1jYWNoZSIsCiAgICAiZGVzdGluYXRpb24iOiAiL3RvcGljL3J1Y2lvLmV2ZW50cy5pbnQiLAogICAgInBvcnQiOiAiNjExMjMiLAogICAgInZvbmFtZSI6ICJmZXJtaWxhYiIKICB9LAogICJtZXNzYWdpbmctaGVybWVzIjogewogICAgImJyb2tlcl92aXJ0dWFsX2hvc3QiOiAiLyIsCiAgICAiYnJva2VycyI6ICJmbmFsLXJ1Y2lvLW1lc3NlbmdlciIsCiAgICAiZGVzdGluYXRpb24iOiAiL3RvcGljL3J1Y2lvLmV2ZW50cy5pbnQiLAogICAgImVtYWlsX2Zyb20iOiAiUnVjaW8gXHUwMDNjYXRsYXMtYWRjLWRkbS1zdXBwb3J0QGNlcm4uY2giLAogICAgImVtYWlsX3Rlc3QiOiAiIiwKICAgICJub25zc2xfcG9ydCI6ICI2MTYxMyIsCiAgICAicGFzc3dvcmQiOiAiZ3Vlc3QiLAogICAgInBvcnQiOiAiNjE2MTMiLAogICAgInNzbF9jZXJ0X2ZpbGUiOiAiL29wdC9ydWNpby9jZXJ0cy9ob3N0Y2VydC5wZW0iLAogICAgInNzbF9rZXlfZmlsZSI6ICIvb3B0L3J1Y2lvL2tleXMvaG9zdGtleS5wZW0iLAogICAgInVzZV9zc2wiOiAiRmFsc2UiLAogICAgInVzZXJuYW1lIjogImd1ZXN0IiwKICAgICJ2b25hbWUiOiAiaW50IgogIH0sCiAgInBvbGljeSI6IHsKICAgICJwYWNrYWdlIjogImZlcm1pbGFiIgogIH0KfQ=="
 ---
 # Source: rucio-daemons/templates/transmogrifier.yaml
 apiVersion: v1
@@ -264,7 +278,7 @@ metadata:
   name: fnal-rucio-daemons.config.transmogrifier
   labels:
     app: rucio-daemons-transmogrifier
-    chart: "rucio-daemons-32.0.0"
+    chart: "rucio-daemons-32.0.2"
     release: "fnal"
     heritage: "Helm"
 type: Opaque
@@ -278,7 +292,7 @@ metadata:
   name: fnal-rucio-daemons.config.undertaker
   labels:
     app: rucio-daemons-undertaker
-    chart: "rucio-daemons-32.0.0"
+    chart: "rucio-daemons-32.0.2"
     release: "fnal"
     heritage: "Helm"
 type: Opaque
@@ -308,7 +322,7 @@ metadata:
   labels:
     app: rucio-daemons-abacus-account
     app-group: rucio-daemons
-    chart: rucio-daemons-32.0.0
+    chart: rucio-daemons-32.0.2
     release: fnal
     heritage: Helm
 spec:
@@ -352,7 +366,7 @@ spec:
           secretName: fnal-policy-package
       containers:
         - name: rucio-daemons
-          image: "rucio/rucio-daemons:release-32.3.0"
+          image: "rucio/rucio-daemons:release-32.4.0"
           imagePullPolicy: Always
           volumeMounts:
             - name: proxy-volume
@@ -401,7 +415,7 @@ metadata:
   labels:
     app: rucio-daemons-abacus-collection-replica
     app-group: rucio-daemons
-    chart: rucio-daemons-32.0.0
+    chart: rucio-daemons-32.0.2
     release: fnal
     heritage: Helm
 spec:
@@ -445,7 +459,7 @@ spec:
           secretName: fnal-policy-package
       containers:
         - name: rucio-daemons
-          image: "rucio/rucio-daemons:release-32.3.0"
+          image: "rucio/rucio-daemons:release-32.4.0"
           imagePullPolicy: Always
           volumeMounts:
             - name: proxy-volume
@@ -494,7 +508,7 @@ metadata:
   labels:
     app: rucio-daemons-abacus-rse
     app-group: rucio-daemons
-    chart: rucio-daemons-32.0.0
+    chart: rucio-daemons-32.0.2
     release: fnal
     heritage: Helm
 spec:
@@ -538,7 +552,7 @@ spec:
           secretName: fnal-policy-package
       containers:
         - name: rucio-daemons
-          image: "rucio/rucio-daemons:release-32.3.0"
+          image: "rucio/rucio-daemons:release-32.4.0"
           imagePullPolicy: Always
           volumeMounts:
             - name: proxy-volume
@@ -587,7 +601,7 @@ metadata:
   labels:
     app: rucio-daemons-automatix
     app-group: rucio-daemons
-    chart: rucio-daemons-32.0.0
+    chart: rucio-daemons-32.0.2
     release: fnal
     heritage: Helm
 spec:
@@ -610,7 +624,7 @@ spec:
         release: fnal
         rucio-daemon: automatix
       annotations:
-        checksum/config: 040f713eaa530dc5dfb69ae450cc0fca95617568
+        checksum/config: 87f3b010e9674e7242352d044f441a499b9a8f94
     spec:
       serviceAccountName: useroot
       volumes:
@@ -640,7 +654,7 @@ spec:
           secretName: fnal-rucio-x509up
       containers:
         - name: rucio-daemons
-          image: "rucio/rucio-daemons:release-32.3.0"
+          image: "rucio/rucio-daemons:release-32.4.0"
           imagePullPolicy: Always
           volumeMounts:
             - name: proxy-volume
@@ -698,7 +712,7 @@ metadata:
   labels:
     app: rucio-daemons-conveyor-finisher
     app-group: rucio-daemons
-    chart: rucio-daemons-32.0.0
+    chart: rucio-daemons-32.0.2
     release: fnal
     heritage: Helm
 spec:
@@ -721,7 +735,7 @@ spec:
         release: fnal
         rucio-daemon: conveyor-finisher
       annotations:
-        checksum/config: 040f713eaa530dc5dfb69ae450cc0fca95617568
+        checksum/config: 87f3b010e9674e7242352d044f441a499b9a8f94
     spec:
       serviceAccountName: useroot
       volumes:
@@ -742,7 +756,7 @@ spec:
           secretName: fnal-policy-package
       containers:
         - name: rucio-daemons
-          image: "rucio/rucio-daemons:release-32.3.0"
+          image: "rucio/rucio-daemons:release-32.4.0"
           imagePullPolicy: Always
           volumeMounts:
             - name: proxy-volume
@@ -791,7 +805,7 @@ metadata:
   labels:
     app: rucio-daemons-conveyor-poller
     app-group: rucio-daemons
-    chart: rucio-daemons-32.0.0
+    chart: rucio-daemons-32.0.2
     release: fnal
     heritage: Helm
 spec:
@@ -814,7 +828,7 @@ spec:
         release: fnal
         rucio-daemon: conveyor-poller
       annotations:
-        checksum/config: 040f713eaa530dc5dfb69ae450cc0fca95617568
+        checksum/config: 87f3b010e9674e7242352d044f441a499b9a8f94
     spec:
       serviceAccountName: useroot
       volumes:
@@ -835,7 +849,7 @@ spec:
           secretName: fnal-policy-package
       containers:
         - name: rucio-daemons
-          image: "rucio/rucio-daemons:release-32.3.0"
+          image: "rucio/rucio-daemons:release-32.4.0"
           imagePullPolicy: Always
           volumeMounts:
             - name: proxy-volume
@@ -884,7 +898,7 @@ metadata:
   labels:
     app: rucio-daemons-conveyor-stager
     app-group: rucio-daemons
-    chart: rucio-daemons-32.0.0
+    chart: rucio-daemons-32.0.2
     release: fnal
     heritage: Helm
 spec:
@@ -907,7 +921,7 @@ spec:
         release: fnal
         rucio-daemon: conveyor-stager
       annotations:
-        checksum/config: 040f713eaa530dc5dfb69ae450cc0fca95617568
+        checksum/config: 87f3b010e9674e7242352d044f441a499b9a8f94
     spec:
       serviceAccountName: useroot
       volumes:
@@ -928,7 +942,7 @@ spec:
           secretName: fnal-policy-package
       containers:
         - name: rucio-daemons
-          image: "rucio/rucio-daemons:release-32.3.0"
+          image: "rucio/rucio-daemons:release-32.4.0"
           imagePullPolicy: Always
           volumeMounts:
             - name: proxy-volume
@@ -977,7 +991,7 @@ metadata:
   labels:
     app: rucio-daemons-conveyor-submitter
     app-group: rucio-daemons
-    chart: rucio-daemons-32.0.0
+    chart: rucio-daemons-32.0.2
     release: fnal
     heritage: Helm
 spec:
@@ -1000,7 +1014,7 @@ spec:
         release: fnal
         rucio-daemon: conveyor-submitter
       annotations:
-        checksum/config: 040f713eaa530dc5dfb69ae450cc0fca95617568
+        checksum/config: 87f3b010e9674e7242352d044f441a499b9a8f94
     spec:
       serviceAccountName: useroot
       volumes:
@@ -1021,7 +1035,7 @@ spec:
           secretName: fnal-policy-package
       containers:
         - name: rucio-daemons
-          image: "rucio/rucio-daemons:release-32.3.0"
+          image: "rucio/rucio-daemons:release-32.4.0"
           imagePullPolicy: Always
           volumeMounts:
             - name: proxy-volume
@@ -1062,6 +1076,109 @@ spec:
               cpu: 700m
               memory: 200Mi
 ---
+# Source: rucio-daemons/templates/hermes.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fnal-hermes
+  labels:
+    app: rucio-daemons-hermes
+    app-group: rucio-daemons
+    chart: rucio-daemons-32.0.2
+    release: fnal
+    heritage: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rucio-daemons-hermes
+      release: fnal
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  minReadySeconds: 5
+  template:
+    metadata:
+      labels:
+        app: rucio-daemons-hermes
+        app-group: rucio-daemons
+        release: fnal
+        rucio-daemon: hermes
+      annotations:
+        checksum/config: 87f3b010e9674e7242352d044f441a499b9a8f94
+    spec:
+      serviceAccountName: useroot
+      volumes:
+        - name: config-common
+          secret:
+            secretName: fnal-rucio-daemons.config.common
+        - name: config-component
+          secret:
+            secretName: fnal-rucio-daemons.config.hermes
+
+        - name: usercert
+          secret:
+            secretName: fnal-hermes-cert
+        - name: userkey
+          secret:
+            secretName: fnal-hermes-key
+
+        - name: policy-package
+          secret:
+            secretName: fnal-policy-package
+        - name: hermes-patch-20231027
+          secret:
+            secretName: fnal-hermes-patch-20231027
+      containers:
+        - name: rucio-daemons
+          image: "rucio/rucio-daemons:release-32.4.0"
+          imagePullPolicy: Always
+          volumeMounts:
+
+            - name: usercert
+              mountPath: /opt/rucio/certs/
+            - name: userkey
+              mountPath: /opt/rucio/keys/
+
+            - name: config-common
+              mountPath: /opt/rucio/etc/conf.d/10_common.json
+              subPath: common.json
+            - name: config-component
+              mountPath: /opt/rucio/etc/conf.d/20_component.json
+              subPath: component.json
+            - name: policy-package
+              mountPath: /opt/rucio/permissions/fermilab
+            - name: hermes-patch-20231027
+              mountPath: /usr/local/lib/python3.9/site-packages/rucio/daemons/hermes/hermes.py
+              subPath: "hermes.py"
+          ports:
+            - name: metrics
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: RUCIO_OVERRIDE_CONFIGS
+              value: "/opt/rucio/etc/conf.d/"
+            - name: RUCIO_DAEMON
+              value: "hermes"
+            - name: RUCIO_DAEMON_ARGS
+              value: " --threads 1  --bulk 1000"
+            - name: PYTHONPATH
+              value: /opt/rucio/permissions
+            - name: RUCIO_CFG_DATABASE_DEFAULT
+              valueFrom:
+                secretKeyRef:
+                  key: db-connstr.txt
+                  name: fnal-db-connstr
+          resources:
+            limits:
+              cpu: 700m
+              memory: 200Mi
+            requests:
+              cpu: 700m
+              memory: 200Mi
+---
 # Source: rucio-daemons/templates/judge.yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -1070,7 +1187,7 @@ metadata:
   labels:
     app: rucio-daemons-judge-cleaner
     app-group: rucio-daemons
-    chart: rucio-daemons-32.0.0
+    chart: rucio-daemons-32.0.2
     release: fnal
     heritage: Helm
 spec:
@@ -1093,7 +1210,7 @@ spec:
         release: fnal
         rucio-daemon: judge-cleaner
       annotations:
-        checksum/config: 040f713eaa530dc5dfb69ae450cc0fca95617568
+        checksum/config: 87f3b010e9674e7242352d044f441a499b9a8f94
     spec:
       serviceAccountName: useroot
       volumes:
@@ -1114,7 +1231,7 @@ spec:
           secretName: fnal-policy-package
       containers:
         - name: rucio-daemons
-          image: "rucio/rucio-daemons:release-32.3.0"
+          image: "rucio/rucio-daemons:release-32.4.0"
           imagePullPolicy: Always
           volumeMounts:
             - name: proxy-volume
@@ -1163,7 +1280,7 @@ metadata:
   labels:
     app: rucio-daemons-judge-evaluator
     app-group: rucio-daemons
-    chart: rucio-daemons-32.0.0
+    chart: rucio-daemons-32.0.2
     release: fnal
     heritage: Helm
 spec:
@@ -1186,7 +1303,7 @@ spec:
         release: fnal
         rucio-daemon: judge-evaluator
       annotations:
-        checksum/config: 040f713eaa530dc5dfb69ae450cc0fca95617568
+        checksum/config: 87f3b010e9674e7242352d044f441a499b9a8f94
     spec:
       serviceAccountName: useroot
       volumes:
@@ -1207,7 +1324,7 @@ spec:
           secretName: fnal-policy-package
       containers:
         - name: rucio-daemons
-          image: "rucio/rucio-daemons:release-32.3.0"
+          image: "rucio/rucio-daemons:release-32.4.0"
           imagePullPolicy: Always
           volumeMounts:
             - name: proxy-volume
@@ -1256,7 +1373,7 @@ metadata:
   labels:
     app: rucio-daemons-judge-injector
     app-group: rucio-daemons
-    chart: rucio-daemons-32.0.0
+    chart: rucio-daemons-32.0.2
     release: fnal
     heritage: Helm
 spec:
@@ -1279,7 +1396,7 @@ spec:
         release: fnal
         rucio-daemon: judge-injector
       annotations:
-        checksum/config: 040f713eaa530dc5dfb69ae450cc0fca95617568
+        checksum/config: 87f3b010e9674e7242352d044f441a499b9a8f94
     spec:
       serviceAccountName: useroot
       volumes:
@@ -1300,7 +1417,7 @@ spec:
           secretName: fnal-policy-package
       containers:
         - name: rucio-daemons
-          image: "rucio/rucio-daemons:release-32.3.0"
+          image: "rucio/rucio-daemons:release-32.4.0"
           imagePullPolicy: Always
           volumeMounts:
             - name: proxy-volume
@@ -1349,7 +1466,7 @@ metadata:
   labels:
     app: rucio-daemons-judge-repairer
     app-group: rucio-daemons
-    chart: rucio-daemons-32.0.0
+    chart: rucio-daemons-32.0.2
     release: fnal
     heritage: Helm
 spec:
@@ -1372,7 +1489,7 @@ spec:
         release: fnal
         rucio-daemon: judge-repairer
       annotations:
-        checksum/config: 040f713eaa530dc5dfb69ae450cc0fca95617568
+        checksum/config: 87f3b010e9674e7242352d044f441a499b9a8f94
     spec:
       serviceAccountName: useroot
       volumes:
@@ -1393,7 +1510,7 @@ spec:
           secretName: fnal-policy-package
       containers:
         - name: rucio-daemons
-          image: "rucio/rucio-daemons:release-32.3.0"
+          image: "rucio/rucio-daemons:release-32.4.0"
           imagePullPolicy: Always
           volumeMounts:
             - name: proxy-volume
@@ -1442,7 +1559,7 @@ metadata:
   labels:
     app: rucio-daemons-minos
     app-group: rucio-daemons
-    chart: rucio-daemons-32.0.0
+    chart: rucio-daemons-32.0.2
     release: fnal
     heritage: Helm
 spec:
@@ -1465,7 +1582,7 @@ spec:
         release: fnal
         rucio-daemon: minos
       annotations:
-        checksum/config: 040f713eaa530dc5dfb69ae450cc0fca95617568
+        checksum/config: 87f3b010e9674e7242352d044f441a499b9a8f94
     spec:
       serviceAccountName: useroot
       volumes:
@@ -1486,7 +1603,7 @@ spec:
           secretName: fnal-policy-package
       containers:
         - name: rucio-daemons
-          image: "rucio/rucio-daemons:release-32.3.0"
+          image: "rucio/rucio-daemons:release-32.4.0"
           imagePullPolicy: Always
           volumeMounts:
             - name: proxy-volume
@@ -1535,7 +1652,7 @@ metadata:
   labels:
     app: rucio-daemons-minos-temporary-expiration
     app-group: rucio-daemons
-    chart: rucio-daemons-32.0.0
+    chart: rucio-daemons-32.0.2
     release: fnal
     heritage: Helm
 spec:
@@ -1558,7 +1675,7 @@ spec:
         release: fnal
         rucio-daemon: minos-temporary-expiration
       annotations:
-        checksum/config: 040f713eaa530dc5dfb69ae450cc0fca95617568
+        checksum/config: 87f3b010e9674e7242352d044f441a499b9a8f94
     spec:
       serviceAccountName: useroot
       volumes:
@@ -1579,7 +1696,7 @@ spec:
           secretName: fnal-policy-package
       containers:
         - name: rucio-daemons
-          image: "rucio/rucio-daemons:release-32.3.0"
+          image: "rucio/rucio-daemons:release-32.4.0"
           imagePullPolicy: Always
           volumeMounts:
             - name: proxy-volume
@@ -1628,7 +1745,7 @@ metadata:
   labels:
     app: rucio-daemons-necromancer
     app-group: rucio-daemons
-    chart: rucio-daemons-32.0.0
+    chart: rucio-daemons-32.0.2
     release: fnal
     heritage: Helm
 spec:
@@ -1651,7 +1768,7 @@ spec:
         release: fnal
         rucio-daemon: necromancer
       annotations:
-        checksum/config: 040f713eaa530dc5dfb69ae450cc0fca95617568
+        checksum/config: 87f3b010e9674e7242352d044f441a499b9a8f94
     spec:
       serviceAccountName: useroot
       volumes:
@@ -1672,7 +1789,7 @@ spec:
           secretName: fnal-policy-package
       containers:
         - name: rucio-daemons
-          image: "rucio/rucio-daemons:release-32.3.0"
+          image: "rucio/rucio-daemons:release-32.4.0"
           imagePullPolicy: Always
           volumeMounts:
             - name: proxy-volume
@@ -1721,7 +1838,7 @@ metadata:
   labels:
     app: rucio-daemons-reaper
     app-group: rucio-daemons
-    chart: rucio-daemons-32.0.0
+    chart: rucio-daemons-32.0.2
     release: fnal
     heritage: Helm
 spec:
@@ -1744,7 +1861,7 @@ spec:
         release: fnal
         rucio-daemon: reaper
       annotations:
-        checksum/config: 040f713eaa530dc5dfb69ae450cc0fca95617568
+        checksum/config: 87f3b010e9674e7242352d044f441a499b9a8f94
     spec:
       serviceAccountName: useroot
       volumes:
@@ -1765,7 +1882,7 @@ spec:
           secretName: fnal-policy-package
       containers:
         - name: rucio-daemons
-          image: "rucio/rucio-daemons:release-32.3.0"
+          image: "rucio/rucio-daemons:release-32.4.0"
           imagePullPolicy: Always
           volumeMounts:
             - name: proxy-volume
@@ -1820,7 +1937,7 @@ metadata:
   labels:
     app: rucio-daemons-replica-recoverer
     app-group: rucio-daemons
-    chart: rucio-daemons-32.0.0
+    chart: rucio-daemons-32.0.2
     release: fnal
     heritage: Helm
 spec:
@@ -1843,7 +1960,7 @@ spec:
         release: fnal
         rucio-daemon: replica-recoverer
       annotations:
-        checksum/config: 040f713eaa530dc5dfb69ae450cc0fca95617568
+        checksum/config: 87f3b010e9674e7242352d044f441a499b9a8f94
     spec:
       serviceAccountName: useroot
       volumes:
@@ -1864,7 +1981,7 @@ spec:
           secretName: fnal-policy-package
       containers:
         - name: rucio-daemons
-          image: "rucio/rucio-daemons:release-32.3.0"
+          image: "rucio/rucio-daemons:release-32.4.0"
           imagePullPolicy: Always
           volumeMounts:
             - name: proxy-volume
@@ -1913,7 +2030,7 @@ metadata:
   labels:
     app: rucio-daemons-transmogrifier
     app-group: rucio-daemons
-    chart: rucio-daemons-32.0.0
+    chart: rucio-daemons-32.0.2
     release: fnal
     heritage: Helm
 spec:
@@ -1936,7 +2053,7 @@ spec:
         release: fnal
         rucio-daemon: transmogrifier
       annotations:
-        checksum/config: 040f713eaa530dc5dfb69ae450cc0fca95617568
+        checksum/config: 87f3b010e9674e7242352d044f441a499b9a8f94
     spec:
       serviceAccountName: useroot
       volumes:
@@ -1957,7 +2074,7 @@ spec:
           secretName: fnal-policy-package
       containers:
         - name: rucio-daemons
-          image: "rucio/rucio-daemons:release-32.3.0"
+          image: "rucio/rucio-daemons:release-32.4.0"
           imagePullPolicy: Always
           volumeMounts:
             - name: proxy-volume
@@ -2006,7 +2123,7 @@ metadata:
   labels:
     app: rucio-daemons-undertaker
     app-group: rucio-daemons
-    chart: rucio-daemons-32.0.0
+    chart: rucio-daemons-32.0.2
     release: fnal
     heritage: Helm
 spec:
@@ -2029,7 +2146,7 @@ spec:
         release: fnal
         rucio-daemon: undertaker
       annotations:
-        checksum/config: 040f713eaa530dc5dfb69ae450cc0fca95617568
+        checksum/config: 87f3b010e9674e7242352d044f441a499b9a8f94
     spec:
       serviceAccountName: useroot
       volumes:
@@ -2047,7 +2164,7 @@ spec:
           secretName: fnal-policy-package
       containers:
         - name: rucio-daemons
-          image: "rucio/rucio-daemons:release-32.3.0"
+          image: "rucio/rucio-daemons:release-32.4.0"
           imagePullPolicy: Always
           volumeMounts:
             - name: config-common

--- a/overlays/int/rucio/helm-rucio-ui.yaml
+++ b/overlays/int/rucio/helm-rucio-ui.yaml
@@ -1,0 +1,183 @@
+---
+# Source: rucio-ui/templates/deployment.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: fnal-rucio-ui.config.yaml
+  labels:
+    app: rucio-ui
+    chart: rucio-ui-32.0.0
+    release: "fnal"
+    heritage: "Helm"
+type: Opaque
+data:
+  common.json: "ewogICJib290c3RyYXAiOiB7CiAgICAieDUwOV9lbWFpbCI6ICJiandoaXRlQGZuYWwuZ292IiwKICAgICJ4NTA5X2lkZW50aXR5IjogIi9EQz1vcmcvREM9Y2lsb2dvbi9DPVVTL089RmVybWkgTmF0aW9uYWwgQWNjZWxlcmF0b3IgTGFib3JhdG9yeS9PVT1QZW9wbGUvQ049QnJhbmRvbiBXaGl0ZS9DTj1VSUQ6Ymp3aGl0ZSIKICB9LAogICJjb3JlIjogewogICAgInVzZV90ZW1wX3RhYmxlcyI6ICJUcnVlIgogIH0sCiAgImRhdGFiYXNlIjoge30sCiAgInBvbGljeSI6IHsKICAgICJwYWNrYWdlIjogImZlcm1pbGFiIgogIH0sCiAgIndlYnVpIjogewogICAgInVzZXJjZXJ0IjogIi9vcHQvcnVjaW8vZXRjL3VzZXJjZXJ0X3dpdGhfa2V5LnBlbSIKICB9Cn0="
+---
+# Source: rucio-ui/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: fnal-rucio-ui.cfg
+  labels:
+    app: rucio-ui
+    chart: "rucio-ui-32.0.0"
+    release: "fnal"
+    heritage: "Helm"
+type: Opaque
+data:
+  legacy_dn: "VHJ1ZQ=="
+  log_dir: "L3J1Y2lvL2xvZ3M="
+---
+# Source: rucio-ui/templates/config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fnal-rucio-ui-aliases
+  labels:
+    app: fnal-rucio-ui
+    chart: "rucio-ui-32.0.0"
+    release: "fnal"
+    heritage: "Helm"
+data:
+  aliases.conf: |+
+    Alias /media        /opt/rucio/.venv/lib/python2.7/site-packages/rucio/web/ui/media
+    Alias /static       /opt/rucio/.venv/lib/python2.7/site-packages/rucio/web/ui/static
+    WSGIScriptAlias /   /opt/rucio/.venv/lib/python2.7/site-packages/rucio/web/ui/main.py
+---
+# Source: rucio-ui/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: fnal-rucio-ui
+  labels:
+    app: rucio-ui
+    chart: rucio-ui-32.0.0
+    release: fnal
+    heritage: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 443
+      targetPort: 443
+      protocol: TCP
+      name: https
+  selector:
+    app: rucio-ui
+    release: fnal
+---
+# Source: rucio-ui/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fnal-rucio-ui
+  labels:
+    app: rucio-ui
+    chart: rucio-ui-32.0.0
+    release: fnal
+    heritage: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rucio-ui
+      release: fnal
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  minReadySeconds: 5
+  template:
+    metadata:
+      labels:
+        app: rucio-ui
+        release: fnal
+      annotations:
+        checksum/config: 22b7f9823f65d3edf293dc13d890c7aa89fff50c
+    spec:
+      serviceAccountName: useroot
+      volumes:
+      - name: config
+        secret:
+          secretName: fnal-rucio-ui.config.yaml
+      - name: aliases
+        configMap:
+          name: fnal-rucio-ui-aliases
+      - name: httpdlog
+        emptyDir: {}
+      - name: hostcert
+        secret:
+          secretName: fnal-hostcert
+      - name: hostkey
+        secret:
+          secretName: fnal-hostkey
+      - name: cafile
+        secret:
+          secretName: fnal-cafile
+      - name: policy-package
+        secret:
+          secretName: fnal-policy-package
+      containers:
+        - name: rucio-ui
+          image: "rucio/rucio-ui:release-32.3.1"
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+            - name: https
+              containerPort: 443
+              protocol: TCP
+          volumeMounts:
+            - name: config
+              mountPath: /opt/rucio/etc/conf.d/10_common.json
+              subPath: common.json
+            - name: httpdlog
+              mountPath: /var/log/httpd
+            - name: aliases
+              mountPath: /opt/rucio/etc/aliases.conf
+              subPath: aliases.conf
+            - name: hostcert
+              mountPath: /etc/grid-security/hostcert.pem
+              subPath: hostcert.pem
+            - name: hostkey
+              mountPath: /etc/grid-security/hostkey.pem
+              subPath: hostkey.pem
+            - name: cafile
+              mountPath: /etc/grid-security/ca.pem
+              subPath: ca.pem
+            - name: policy-package
+              mountPath: /opt/rucio/permissions/fermilab
+              subPath: 
+          env:
+            - name: RUCIO_HTTPD_LEGACY_DN
+              valueFrom:
+                secretKeyRef:
+                  name: fnal-rucio-ui.cfg
+                  key: legacy_dn
+            - name: RUCIO_HTTPD_LOG_DIR
+              valueFrom:
+                secretKeyRef:
+                  name: fnal-rucio-ui.cfg
+                  key: log_dir
+            - name: EXPERIMENT
+              value: "Uses $EXPERIMENT"
+            - name: PYTHONPATH
+              value: "/opt/rucio/permissions"
+            - name: RUCIO_ENABLE_LOGFILE
+              value: "True"
+
+            - name: RUCIO_PROXY
+              value: int-rucio.fnal.gov
+            - name: RUCIO_AUTH_PROXY
+              value: int-rucio.fnal.gov
+            - name: RUCIO_DEFINE_ALIASES
+              value: "True"
+            - name: RUCIO_OVERRIDE_CONFIGS
+              value: "/opt/rucio/etc/conf.d/"
+            - name: RUCIO_LOG_FORMAT
+              value: '[%{%Y-%m-%d %H:%M:%S}t]\t%v\t%h\t%{X-Forwarded-For}i\t%{X-Rucio-RequestId}i\t%>s\t%I\t%B\t%D\t\"%r\"\t\"%{X-Rucio-Auth-Token}i\"\t\"%{User-Agent}i\"\t%{X-Rucio-Script}i'
+            - name: RUCIO_ENABLE_SSL
+              value: "True"
+          resources:
+            {}

--- a/overlays/int/rucio/kustomization.yaml
+++ b/overlays/int/rucio/kustomization.yaml
@@ -2,15 +2,17 @@
 resources:
 - helm-rucio-server.yaml
 - helm-rucio-daemons.yaml
+- helm-rucio-ui.yaml
 - cache.yaml
 - prometheus.yaml
 - messenger.yaml
+- routes.yaml
 #- statsd.yaml
-#- helm-rucio-ui.yaml
 #
 patchesStrategicMerge:
 - patch-service.yaml
 - grid-certificates-patch.yaml
+- patch-webui.yaml
 #- rucio-env-patch.yaml
 
 secretGenerator:
@@ -89,26 +91,30 @@ secretGenerator:
   files:
   - vomses=etc/vomses
 
-# RabbitMQ Configuration File
+# RabbitMQ Configuration Files
 - name: fnal-rabbitmq-conf
   files:
   - rabbitmq.conf=etc/rabbitmq.conf
+- name: fnal-rabbitmq-enabled-plugins
+  files:
+  - enabled_plugins=etc/enabled_plugins
 
 ## ingress
 #- name: rucio-server.tls-secret
 #  files:
 #  - cert=etc/.secrets/hostcert.pem
 #  - key=etc/.secrets/hostkey.pem
-## webui
-#- name: fnal-hostcert
-#  files:
-#  - hostcert.pem=etc/.secrets/hostcert.pem
-#- name: fnal-hostkey
-#  files:
-#  - hostkey.pem=etc/.secrets/hostkey.pem
-#- name: fnal-cafile
-#  files:
-#  - ca.pem=etc/.secrets/ca.pem
+#
+# webui
+- name: fnal-hostcert
+  files:
+  - hostcert.pem=etc/.secrets/hostcert.pem
+- name: fnal-hostkey
+  files:
+  - hostkey.pem=etc/.secrets/hostkey.pem
+- name: fnal-cafile
+  files:
+  - ca.pem=etc/.secrets/ca.pem
 ## lsst customization
 #- name: fnal-lsst-schema-file
 #  files:
@@ -116,3 +122,8 @@ secretGenerator:
 #  options:
 #    disableNameSuffixHash: true
 ## automatix input
+#
+# hermes patch file
+- name: fnal-hermes-patch-20231027
+  files:
+  - hermes.py=etc/hermes_patch_20231027.py

--- a/overlays/int/rucio/messenger-fnal.yaml
+++ b/overlays/int/rucio/messenger-fnal.yaml
@@ -1,0 +1,75 @@
+---
+# Source: rucio-messenger/templates/messenger_service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: fnal-rucio-messenger
+  labels:
+    app: rucio-messenger
+    chart: rucio-messenger-0.3.0
+    release: rucio-int-messenger
+    heritage: Helm
+spec:
+  type: ClusterIP 
+  ports:
+    - port: 443
+      targetPort: 443
+      protocol: TCP
+      name: https
+  selector:
+    app: rucio-messenger
+    release: rucio-int-messenger
+---
+# Source: rucio-messenger/templates/messenger_deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fnal-rucio-messenger
+  labels:
+    app: rucio-messenger
+    chart: rucio-messenger-0.3.0
+    release: rucio-int-messenger
+    heritage: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: fnal-rucio-messenger
+      release: rucio-int-messenger
+  minReadySeconds: 
+  template:
+    metadata:
+      labels:
+        app: fnal-rucio-messenger
+        release: rucio-int-messenger
+    spec:
+      serviceAccountName: useroot
+      volumes:
+        - name: ssl-credentials
+          secret:
+            secretName: ssl-secrets
+        - name: rabbitmq-conf
+          secret:
+            secretName: fnal-rabbitmq-conf
+        - name: enabled-plugins
+          secret: 
+            secretName: fnal-rabbitmq-enabled-plugins
+      containers:
+        - name: rucio-messenger
+          image: "imageregistry.fnal.gov/rucio-ams/rucio-ams-messenger:1.29.12"
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: ssl-credentials
+              mountPath: /etc/rabbitmq/ssl
+              readOnly: true
+            - name: rabbitmq-conf
+              mountPath: /etc/rabbitmq/rabbitmq.conf
+              subPath: rabbitmq.conf
+            - name: enabled-plugins
+              mountPath: /etc/rabbitmq/enabled_plugins
+              subPath: enabled_plugins
+          env:
+            - name: EXPERIMENT
+              value: "int"
+            - name: RUCIO_MESSENGER_SERVICE_PORT_HTTPS
+              value: "443"

--- a/overlays/int/rucio/messenger.yaml
+++ b/overlays/int/rucio/messenger.yaml
@@ -1,0 +1,77 @@
+---
+# Source: rucio-messenger/templates/messenger_service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: fnal-rucio-messenger
+  labels:
+    app: rucio-messenger
+    release: fnal
+spec:
+  type: ClusterIP 
+  ports:
+    - port: 443
+      targetPort: 443
+      protocol: TCP
+      name: https
+    - port: 61613
+      targetPort: 61613
+      protocol: TCP
+      name: http
+  selector:
+    app: rucio-messenger
+    release: fnal
+---
+# Source: rucio-messenger/templates/messenger_deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fnal-rucio-messenger
+  labels:
+    app: rucio-messenger
+    release: fnal
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rucio-messenger
+      release: fnal
+  minReadySeconds: 
+  template:
+    metadata:
+      labels:
+        app: rucio-messenger
+        release: fnal
+    spec:
+      serviceAccountName: useroot
+      volumes:
+        - name: ssl-credentials
+          secret:
+            secretName: ssl-secrets
+        - name: rabbitmq-conf
+          secret:
+            secretName: fnal-rabbitmq-conf
+        - name: enabled-plugins
+          secret: 
+            secretName: fnal-rabbitmq-enabled-plugins
+      containers:
+        - name: rucio-messenger
+          image: "rabbitmq:3"
+          imagePullPolicy: Always
+          command: ["rabbitmq-server"]
+          ports:
+            - containerPort: 443
+            - containerPort: 61613
+          volumeMounts:
+            - name: ssl-credentials
+              mountPath: /etc/rabbitmq/ssl
+              readOnly: true
+            - name: rabbitmq-conf
+              mountPath: /etc/rabbitmq/rabbitmq.conf
+              subPath: rabbitmq.conf
+            - name: enabled-plugins
+              mountPath: /etc/rabbitmq/enabled_plugins
+              subPath: enabled_plugins
+          env:
+            - name: EXPERIMENT
+              value: "int"

--- a/overlays/int/rucio/patch-service.yaml
+++ b/overlays/int/rucio/patch-service.yaml
@@ -11,3 +11,10 @@ metadata:
   name: fnal-rucio-messenger
 spec:
   externalIPs: [ 131.225.218.157 ]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: fnal-rucio-ui
+spec:
+  externalIPs: [ 131.225.218.158 ]

--- a/overlays/int/rucio/patch-webui.yaml
+++ b/overlays/int/rucio/patch-webui.yaml
@@ -1,0 +1,15 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fnal-rucio-ui
+spec:
+  template:
+    spec:
+      containers:
+        - name: rucio-ui
+          env:
+            - name: RUCIO_CFG_DATABASE_DEFAULT
+              valueFrom:
+                secretKeyRef:
+                  key: db-connstr.txt
+                  name: fnal-db-connstr

--- a/overlays/int/rucio/routes.yaml
+++ b/overlays/int/rucio/routes.yaml
@@ -1,0 +1,54 @@
+---
+# Source: rucio-routes/templates/messenger_route.yaml
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: rucio-messenger-route
+  labels:
+    app: rucio-messenger 
+    chart: rucio-routes-0.2.0
+    release: rucio-int
+    heritage: Helm
+spec:
+  host: msg-int-rucio.fnal.gov 
+  to:
+    kind: Service
+    name: fnal-rucio-messenger
+  tls:
+    termination: passthrough
+---
+# Source: rucio-routes/templates/service_route.yaml
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: rucio-server-route
+  labels:
+    app: rucio-server 
+    chart: rucio-routes-0.2.0
+    release: rucio-int
+    heritage: Helm
+spec:
+  host: int-rucio.fnal.gov 
+  to:
+    kind: Service
+    name: fnal-rucio-server
+  tls:
+    termination: passthrough
+---
+# Source: rucio-routes/templates/webui_route.yaml
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: rucio-ui-route
+  labels:
+    app: rucio-ui 
+    chart: rucio-routes-0.2.0
+    release: rucio-int
+    heritage: Helm
+spec:
+  host: webui-int-rucio.fnal.gov 
+  to:
+    kind: Service
+    name: fnal-rucio-ui
+  tls:
+    termination: passthrough

--- a/overlays/int/rucio/values-rucio-daemons.yaml
+++ b/overlays/int/rucio/values-rucio-daemons.yaml
@@ -16,7 +16,7 @@ conveyorStagerCount: 1
 conveyorThrottlerCount: 0
 conveyorPreparerCount: 0
 darkReaperCount: 0
-hermesCount: 0
+hermesCount: 1
 hermesLegacyCount: 0
 judgeCleanerCount: 1
 judgeEvaluatorCount: 1
@@ -36,7 +36,7 @@ serviceAccountName: useroot
 
 image:
   repository: rucio/rucio-daemons
-  tag: release-32.3.0
+  tag: release-32.4.0
   pullPolicy: Always
 
 strategy:
@@ -408,6 +408,9 @@ hermes:
   secretMounts:
       - secretName: policy-package
         mountPath: /opt/rucio/permissions/fermilab
+      - secretName: hermes-patch-20231027
+        mountPath: /usr/local/lib/python3.9/site-packages/rucio/daemons/hermes/hermes.py
+        subPath: hermes.py
 
 hermesLegacy:
   threads: 1
@@ -893,16 +896,20 @@ config:
     # brokers: "dashb-test-mb.cern.ch"
     # voname: "atlas"
 
+  hermes:
+    services_list: "activemq"
+
   messaging-hermes:
     username: "guest"
     password: "guest"
-    port: "443"
-    # nonssl_port: ""
-    use_ssl: "True"
-    ssl_key_file: "/etc/grid-security/hostkey.pem"
-    ssl_cert_file: "/etc/grid-security/hostcert.pem"
+    broker_virtual_host: "/"
+    port: "61613"
+    nonssl_port: "61613"
+    use_ssl: "False"
+    ssl_key_file: "/opt/rucio/keys/hostkey.pem"
+    ssl_cert_file: "/opt/rucio/certs/hostcert.pem"
     destination: "/topic/rucio.events.int"
-    brokers: "rucio-messenger"
+    brokers: "fnal-rucio-messenger"
     voname: "int"
     email_from: "Rucio <atlas-adc-ddm-support@cern.ch"
     email_test: ""

--- a/overlays/int/rucio/values-rucio-server.yaml
+++ b/overlays/int/rucio/values-rucio-server.yaml
@@ -76,33 +76,10 @@ minReadySeconds: 5
   #authServer: 5
   #traceServer: 5
 
-readinessProbe:
-  server:
-    initialDelaySeconds: 5
-    periodSeconds: 10
-    timeoutSeconds: 5
-  authServer:
-    initialDelaySeconds: 5
-    periodSeconds: 10
-    timeoutSeconds: 5
-  traceServer:
-    initialDelaySeconds: 5
-    periodSeconds: 10
-    timeoutSeconds: 5
-
 livenessProbe:
-  server:
-    initialDelaySeconds: 10
-    periodSeconds: 20
-    timeoutSeconds: 5
-  authServer:
-    initialDelaySeconds: 10
-    periodSeconds: 20
-    timeoutSeconds: 5
-  traceServer:
-    initialDelaySeconds: 10
-    periodSeconds: 20
-    timeoutSeconds: 5
+  initialDelaySeconds: 10
+  periodSeconds: 20
+  timeoutSeconds: 5
 
 serverType: api
 
@@ -205,8 +182,8 @@ automaticRestart:
       memory: 128Mi
 
 secretMounts:
-    - secretName: policy-package
-      mountPath: /opt/rucio/permissions/fermilab
+  - secretName: policy-package
+    mountPath: /opt/rucio/permissions/fermilab
   # - volumeName: gcssecret
   #   secretName: gcssecret
   #   mountPath: /opt/rucio/etc/gcs_rucio.json
@@ -431,22 +408,6 @@ serverResources:
   requests:
     memory: "200Mi"
     cpu: "200m"
-
-authServerResources:
-  limits:
-    memory: "600Mi"
-    cpu: "700m"
-  requests:
-    memory: "200Mi"
-    cpu: "200m"
-
-traceServerResources: {}
-  # limits:
-  #  cpu: 100m
-  #  memory: 128Mi
-  # requests:
-  #  cpu: 100m
-  #  memory: 128Mi
 
 nodeSelector: {}
 

--- a/overlays/int/rucio/values-rucio-ui.yaml
+++ b/overlays/int/rucio/values-rucio-ui.yaml
@@ -2,23 +2,33 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+serviceAccountName: useroot
+
+rucio_ca_path: /etc/grid-security/certificates
+webui_certkeycombined_path: /etc/grid-security/hostcertkeycombined.pem
+
 ## replicaCount gives the number of server pods to run
 replicaCount: 1
 
 # When set, run extra busybox containers in the relevant pods to also expose the error logs
-exposeErrorLogs: True
+exposeErrorLogs: 0
 
 service:
-  type: NodePort
-  # Run the webui server on port 443 instead of 80 and accept X509 certificates and proxies
-  useSSL: true
+  # type: NodePort
+  # # Run the webui server on port 443 instead of 80 and accept X509 certificates and proxies
+  # useSSL: true
+  # port: 443
+  # targetPort: https
+  # portName: https
+  type: ClusterIP
   port: 443
-  targetPort: https
-  portName: https
+  targetPort: 443
+  tls:
+    enabled: true
 
 image:
   repository: rucio/rucio-ui
-  tag: release-1.21.12
+  tag: release-32.3.1
   pullPolicy: Always
 
 strategy:
@@ -30,18 +40,18 @@ strategy:
 minReadySeconds: 5
 
 proxy:
-  rucioProxy: ""
+  rucioProxy: "int-rucio.fnal.gov"
   # rucioProxyScheme: "https"
-  rucioAuthProxy: ""
+  rucioAuthProxy: "int-rucio.fnal.gov"
   # rucioAuthProxyScheme: "https"
 
 ingress:
-  enabled: false
-  # ingressClassName: traefik
-  annotations: {}
-  path: /
-  hosts: []
-  #   - my.rucio.test
+  enabled: 0
+
+webuiRoute:
+  app: rucio-webui
+  host: webui-int-rucio.fnal.gov
+  serviceName: rucio-int-rucio-ui
 
 additionalSecrets: {}
 # - volumeName: gcssecret
@@ -51,7 +61,8 @@ additionalSecrets: {}
 
 ## values used to configure apache
 httpd_config:
-  legacy_dn: "False"
+  legacy_dn: "True"
+  log_dir: "/rucio/logs"
   # mpm_mode: "event"
   # start_servers: "1"
   # min_spare_threads: "1"
@@ -62,6 +73,16 @@ httpd_config:
 
 ## values used to configure Rucio
 config:
+  core:
+    use_temp_tables: "True"
+
+  bootstrap:
+    x509_identity: "/DC=org/DC=cilogon/C=US/O=Fermi National Accelerator Laboratory/OU=People/CN=Brandon White/CN=UID:bjwhite"
+    x509_email: "bjwhite@fnal.gov"
+
+  policy:
+    package: fermilab
+
   # common:
     ## config.common.logdir: the default directoy to write logs to (default: "/var/log/rucio")
     # logdir: "/var/log/rucio"
@@ -70,44 +91,15 @@ config:
     ## config.common.mailtemplatedir: directory containing the mail templates (default: "/opt/rucio/etc/mail_templates")
     # mailtemplatedir: "/opt/rucio/etc/mail_templates"
 
-  database: {}
-    ## config.database.default: the connection string for the database (default: "sqlite:////tmp/rucio.db")
-    # default: "sqlite:////tmp/rucio.db"
-    ## config.database.schema: the schema used in the DB. only necessary when using Oracle.
-    # schema: ""
-    ## config.database.pool_reset_on_return: set the “reset on return” behavior of the pool (default: "rollback")
-    # pool_reset_on_return: "rollback"
-    ## config.database.echo: flag to control the logging of all statements to stdout (default: "0")
-    # echo: "0"
-    ## config.database.po0l_recycle: this setting causes the pool to recycle connections after the given number of seconds has passed (default: "600")
-    # pool_recycle: "600"
-    ## config.database.pool_size: the number of connections to keep open inside the connection pool
-    # pool_size: ""
-    ## config.database.pool_timeout: number of seconds to wait before giving up on getting a connection from the pool
-    # pool_timeout: ""
-    ## config.database.maxoverflow: the number of connections to allow in connection pool "overflow"
-    # max_overflow: ""
-    ## config.database.powuseraccount: user used to check the DB
-    # powuseraccount: ""
-    ## config.database.powuseraccount: password for user used to check the DB
-    # powuserpassword: ""
-
-  # policy:
-    ## config.permission.policy: (default "generic")
-    # permission: "generic"
-    ## config.permission.schema: (default "generic")
-    # schema: "generic"
-    ## config.permission.lfn2pfn_algorithm_default: (default "hash")
-    # lfn2pfn_algorithm_default: "hash"
-    ## config.permission.support: (default "https://github.com/rucio/rucio/issues/")
-    # support: "https://github.com/rucio/rucio/issues/"
-    ## config.permission.support_rucio: (default "https://github.com/rucio/rucio/issues/")
-    # support_rucio: "https://github.com/rucio/rucio/issues/"
-
   ## Only necessary for webui deployments
-  # webui:
-    ## config.webui.usercert:  (default "/opt/rucio/etc/usercert_with_key.pem")
-    # usercert: "/opt/rucio/etc/usercert_with_key.pem"
+  webui:
+    # config.webui.usercert:  (default "/opt/rucio/etc/usercert_with_key.pem")
+    usercert: "/opt/rucio/etc/usercert_with_key.pem"
+
+optional_config:
+  experiment: Uses $EXPERIMENT
+  rucio_enable_logfile: "True"    
+  pythonpath: /opt/rucio/permissions
 
 resources: {}
   # limits:
@@ -116,6 +108,9 @@ resources: {}
   # requests:
   #  cpu: 100m
   #  memory: 128Mi
+secretMounts:
+  - secretName: policy-package
+    mountPath: /opt/rucio/permissions/fermilab
 
 nodeSelector: {}
 


### PR DESCRIPTION
Enabled rucio-ui
* Added rucio-ui configuration
* Use rucio-ui chart instead of rucio-webui chart

Enabled rucio-messenger configuration
* Messenger now uses official rabbitmq:3 image
* Messenger needs rabbitmq.conf and enabled_plugins as secrets
* Messenger with no_ssl in cluster only

Enabled Hermes Daemon
* Running with a temporary patch, uses no_ssl to connect to broker

Misc
* Enabled rucio-cache for now
* Fixed .gitignore to include messenger.yaml and cache.yaml files for only in overlays
* Added routes.yaml for server, ui and messenger