### PR TITLE
Client image and Sync ferry user script in dune-int

### DIFF
--- a/images/Makefile
+++ b/images/Makefile
@@ -1,5 +1,5 @@
 
-# Use this to control building and pushing of Docker images in a significantly less ugly fashion.
+# Use this to control building and pushing of container images in a significantly less ugly fashion.
 #
 
 # Top level Makefile commands (also can build individual images with `make build-<server|daemons|webui|etc...>`)
@@ -130,14 +130,14 @@ endef
 define build-client-cmd =
 -rm -rf init/permissions
 cp -r permissions-fnal init/permissions
-docker build --label "maintainer=${RUCIO_BUILD_USER}" -t rucio-client --build-arg rucio_version=${RUCIO_AMS_VERSION} client
+podman build --label "maintainer=${RUCIO_BUILD_USER}" -t rucio-client --build-arg rucio_version=${RUCIO_AMS_VERSION} client
 -rm -rf init/permissions
 endef
 
 define build-client-nc-cmd =
 -rm -rf init/permissions
 cp -r permissions-fnal init/permissions
-docker build --label "maintainer=${RUCIO_BUILD_USER}" --no-cache -t rucio-client --build-arg rucio_version=${RUCIO_AMS_VERSION} client
+podman build --label "maintainer=${RUCIO_BUILD_USER}" --no-cache -t rucio-client --build-arg rucio_version=${RUCIO_AMS_VERSION} client
 -rm -rf init/permissions
 endef
 
@@ -250,8 +250,8 @@ define push-daemons-cmd =
 endef
 
 define push-client-cmd =
-	docker tag rucio-client imageregistry.fnal.gov/rucio-ams/rucio-client:${RUCIO_AMS_VERSION_TAG}.fnal
-	docker push imageregistry.fnal.gov/rucio-ams/rucio-client:${RUCIO_AMS_VERSION_TAG}.fnal
+	podman tag rucio-client imageregistry.fnal.gov/rucio-ams/rucio-client:${RUCIO_AMS_VERSION_TAG}.fnal
+	podman push imageregistry.fnal.gov/rucio-ams/rucio-client:${RUCIO_AMS_VERSION_TAG}.fnal
 endef
 
 define push-cache-cmd =

--- a/images/Makefile
+++ b/images/Makefile
@@ -127,6 +127,20 @@ podman build --label "maintainer=${RUCIO_BUILD_USER}" --no-cache -t rucio-init -
 -rm -rf init/permissions
 endef
 
+define build-client-cmd =
+-rm -rf init/permissions
+cp -r permissions-fnal init/permissions
+docker build --label "maintainer=${RUCIO_BUILD_USER}" -t rucio-client --build-arg rucio_version=${RUCIO_AMS_VERSION} client
+-rm -rf init/permissions
+endef
+
+define build-client-nc-cmd =
+-rm -rf init/permissions
+cp -r permissions-fnal init/permissions
+docker build --label "maintainer=${RUCIO_BUILD_USER}" --no-cache -t rucio-client --build-arg rucio_version=${RUCIO_AMS_VERSION} client
+-rm -rf init/permissions
+endef
+
 define build-cache-cmd =
 podman build --label "maintainer=${RUCIO_BUILD_USER}" -t rucio-cache cache
 endef
@@ -196,6 +210,12 @@ build-init:
 	$(build-init-cmd)
 	
 build-init-nc:
+	$(build-init-nc-cmd)	
+
+build-client:
+	$(build-client-cmd)
+	
+build-client-nc:
 	$(build-init-nc-cmd)	
 
 # Image push command definitions

--- a/images/Makefile
+++ b/images/Makefile
@@ -239,7 +239,6 @@ define push-webui-cmd =
 	podman push imageregistry.fnal.gov/rucio-ams/rucio-ams-webui:${RUCIO_AMS_VERSION_TAG}
 endef
 
-
 define push-server-cmd =
 	podman tag rucio-server imageregistry.fnal.gov/rucio-ams/rucio-ams-server:${RUCIO_AMS_VERSION_TAG}
 	podman push imageregistry.fnal.gov/rucio-ams/rucio-ams-server:${RUCIO_AMS_VERSION_TAG}
@@ -248,6 +247,11 @@ endef
 define push-daemons-cmd =
 	podman tag rucio-daemons imageregistry.fnal.gov/rucio-ams/rucio-ams-daemons:${RUCIO_AMS_VERSION_TAG}
 	podman push imageregistry.fnal.gov/rucio-ams/rucio-ams-daemons:${RUCIO_AMS_VERSION_TAG}
+endef
+
+define push-client-cmd =
+	docker tag rucio-client imageregistry.fnal.gov/rucio-ams/rucio-client:${RUCIO_AMS_VERSION_TAG}.fnal
+	docker push imageregistry.fnal.gov/rucio-ams/rucio-client:${RUCIO_AMS_VERSION_TAG}.fnal
 endef
 
 define push-cache-cmd =
@@ -284,3 +288,6 @@ push-cache:
 
 push-messenger:
 	$(push-messenger-cmd)
+
+push-client:
+	$(push-client-cmd)

--- a/images/client/.dockerignore
+++ b/images/client/.dockerignore
@@ -1,4 +1,5 @@
 *
 !scripts/
+!certificates/
 !requirements.txt
 */__pycache__

--- a/images/client/.dockerignore
+++ b/images/client/.dockerignore
@@ -1,0 +1,4 @@
+*
+!scripts/
+!requirements.txt
+*/__pycache__

--- a/images/client/.gitignore
+++ b/images/client/.gitignore
@@ -1,0 +1,2 @@
+venv
+*/__pycache__

--- a/images/client/Dockerfile
+++ b/images/client/Dockerfile
@@ -1,0 +1,32 @@
+FROM --platform=linux/amd64 almalinux:9
+
+ARG rucio_version
+
+RUN dnf upgrade -y && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf
+
+RUN dnf install -y epel-release.noarch && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf
+
+RUN dnf config-manager --set-enabled crb
+
+RUN dnf install -y python3 python3-pip python3-devel \
+    openssl-devel vim git \
+    gfal2-all python3-gfal2 && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf
+
+COPY scripts /scripts
+COPY requirements.txt /requirements.txt
+
+WORKDIR /tmp
+
+RUN pip3 install --no-cache-dir --upgrade pip setuptools && \
+    pip3 install --no-cache-dir rucio-clients==$rucio_version && \
+    pip3 install --no-cache-dir -r /requirements.txt && \
+    pip3 cache purge
+
+ENV X509_USER_PROXY=/opt/proxy/x509up
+ENTRYPOINT ["/bin/bash", "-c", "sleep infinity"]

--- a/images/client/Dockerfile
+++ b/images/client/Dockerfile
@@ -7,6 +7,7 @@ RUN dnf upgrade -y && \
     rm -rf /var/cache/dnf
 
 RUN dnf install -y epel-release.noarch && \
+    dnf install -y https://repo.opensciencegrid.org/osg/3.6/osg-3.6-el9-release-latest.rpm && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 
@@ -14,7 +15,7 @@ RUN dnf config-manager --set-enabled crb
 
 RUN dnf install -y python3 python3-pip python3-devel \
     openssl-devel vim git \
-    gfal2-all python3-gfal2 && \
+    gfal2-all python3-gfal2 osg-wn-client && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 

--- a/images/client/requirements.txt
+++ b/images/client/requirements.txt
@@ -1,0 +1,17 @@
+attrs==23.2.0
+certifi==2024.2.2
+charset-normalizer==3.3.2
+decorator==5.1.1
+dogpile.cache==1.2.2
+idna==3.7
+jsonschema==4.20.0
+jsonschema-specifications==2023.12.1
+pbr==6.0.0
+referencing==0.34.0
+requests==2.31.0
+rpds-py==0.18.0
+rucio-clients==34.1.0
+stevedore==5.2.0
+tabulate==0.9.0
+typing_extensions==4.11.0
+urllib3==1.26.18

--- a/images/client/scripts/FerryClient.py
+++ b/images/client/scripts/FerryClient.py
@@ -1,3 +1,8 @@
+"""
+FerryClient
+
+Module to connect to FERRY
+"""
 import logging
 import os
 
@@ -9,12 +14,12 @@ class FerryClient:
     """
     Client to access FERRY
     """
-
     def __init__(self, logger=None):
         self.logger = logger or logging.getLogger()
         self.server = os.getenv("FERRY_URL", "https://ferry.fnal.gov:8445")
-        self.capath = os.getenv("CA_PATH", "/etc/grid-security/certificates")
-        self.cert = os.getenv("CLIENT_X509_PROXY", "/tmp/x509up_u0")
+        self.capath = os.getenv("CA_PATH" "/etc/grid-security/certificates")
+        self.cert = os.getenv("X509_USER_CERT", "/opt/rucio/certs/usercert.pem")
+        self.key = os.getenv("X509_USER_KEY", "/opt/rucio/keys/userkey.pem")
 
     def get(self, url: str, params: dict = None) -> dict:
         """
@@ -25,7 +30,7 @@ class FerryClient:
         try:
             r = requests.get(url,
                 params=params,
-                cert=self.cert,
+                cert=(self.cert, self.key),
                 verify=self.capath)
         except HTTPError as e:
             self.logger.error(e)
@@ -59,7 +64,7 @@ class FerryClient:
         url = f"{self.server}/getUserCertificateDNs"
         params = {"unitname": unitname, "username": username}
         r = self.get(url, params)
-        return r
+        return r[0]['certificates']
 
     def getUserLdapInfo(self, username: str) -> dict:
         """

--- a/images/client/scripts/FerryClient.py
+++ b/images/client/scripts/FerryClient.py
@@ -1,0 +1,71 @@
+import logging
+import os
+
+import requests
+from requests.exceptions import HTTPError
+
+
+class FerryClient:
+    """
+    Client to access FERRY
+    """
+
+    def __init__(self, logger=None):
+        self.logger = logger or logging.getLogger()
+        self.server = os.getenv("FERRY_URL", "https://ferry.fnal.gov:8445")
+        self.capath = os.getenv("CA_PATH", "/etc/grid-security/certificates")
+        self.cert = os.getenv("CLIENT_X509_PROXY", "/tmp/x509up_u0")
+
+    def get(self, url: str, params: dict = None) -> dict:
+        """
+        Get method for FERRY
+
+        Adds SSL for request
+        """
+        try:
+            r = requests.get(url,
+                params=params,
+                cert=self.cert,
+                verify=self.capath)
+        except HTTPError as e:
+            self.logger.error(e)
+            raise
+
+        data = r.json()
+        return data["ferry_output"]
+
+    def getUserInfo(self, username: str) -> dict:
+        """
+        Fetches user information for a given username
+        """
+        url = f"{self.server}/getUserInfo"
+        params = {"username": username}
+        r = self.get(url, params)
+        return r
+
+    def getAffiliationMembers(self, unitname: str) -> dict:
+        """
+        Fetches members of an affiliation a given unitname
+        """
+        url = f"{self.server}/getAffiliationMembers"
+        params = {"unitname": unitname}
+        r = self.get(url, params)
+        return r
+    
+    def getUserCertificateDNs(self, unitname: str, username: str) -> dict:
+        """
+        Fetches a user's DNs for a specific affiliation
+        """
+        url = f"{self.server}/getUserCertificateDNs"
+        params = {"unitname": unitname, "username": username}
+        r = self.get(url, params)
+        return r
+
+    def getUserLdapInfo(self, username: str) -> dict:
+        """
+        Fetches user's LDAP information
+        """
+        url = f"{self.server}/getUserLdapInfo"
+        params = {"username": username}
+        r = self.get(url, params)
+        return r

--- a/images/client/scripts/sync_ferry_users.py
+++ b/images/client/scripts/sync_ferry_users.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""
+Script to sync FERRY users to Rucio based on vo/afffiliation
+
+Adds FERRY users and identities to Rucio as account type USER.
+Also applies analysis account attributes/policy to these accounts.
+"""
+
+import logging
+import os
+
+from rucio.client import Client
+from rucio.common.exception import AccountNotFound, Duplicate
+
+from FerryClient import FerryClient
+
+
+# setup logger
+logger = logging.getLogger()
+logger.setLevel(logging.DEBUG)
+ch = logging.StreamHandler()
+ch.setLevel(logging.INFO)
+logger.addHandler(ch)
+
+# setup clients
+ferry = FerryClient(logger=logger)
+client = Client()
+
+dry_run = True
+
+ANALYSIS_ATTRIBUTES = [
+    "add_rule",
+    "add_replicas",
+    "add_did",
+    "add_dids",
+    "update_replicas_states"
+]
+
+
+def main():
+    unitname = os.getenv("FERRY_VO", "int")
+    try:
+        members = ferry.getAffiliationMembers(unitname)[0]
+    except Exception as e:
+        logger.error(f"Could not get users in affiliation {unitname}")
+        logger.error(e)
+        raise
+
+    for user in members['users']:
+        username = user['username']
+
+        try:
+            user = ferry.getUserInfo(username)
+            if not user['status'] or user['banned']:
+                continue
+        except:
+            continue
+
+        try:
+            userLdap = ferry.getUserLdapInfo(username)
+            email = userLdap['mail']
+        except Exception as e:
+            logger.error(f"Cannot get userLdapInfo for {username}")
+            logger.error(e)
+            continue
+
+        try:
+           client.get_account(username)
+        except AccountNotFound:
+            logger.info(f"Account {username} not found. Adding...")
+            if not dry_run:
+                client.add_account(username, 'USER', email)
+
+        if not dry_run:
+            logger.info(f"Adding scope for user: {username}")
+            try:
+                client.add_scope(username, f'user.{username}')
+            except Duplicate:
+                logger.info(f"Scope for user {username} already exists")
+
+        # add identities
+        logger.info(f"Adding identities for {username}")
+        dn = ferry.getUserCertificateDNs(unitname, username)
+        if not dry_run:
+            for d in dn:
+                client.add_identity(username, d, "X509", email)
+
+        # add attributes
+        attributes = client.list_account_attributes(username)
+        logger.info(f"Adding analysis attributes")
+        for a in ANALYSIS_ATTRIBUTES:
+            if not dry_run:
+                try:
+                    client.add_account_attribute(username, a, "1")
+                except Duplicate as e:
+                    logger.error(e)
+                    continue
+
+    # delete rucio accounts not in FERRY members
+    rucio_accounts = client.list_accounts(account_type="USER")
+    ferry_accounts = [m['username'] for m in members['users']]
+    for a in rucio_accounts:
+        if a['account'] not in ferry_accounts:
+            logger.info(f"Disabling account {a}")
+            if not dry_run:
+                client.delete_account(a)
+
+
+if __name__ == "__main__":
+    main()

--- a/images/client/scripts/sync_ferry_users.py
+++ b/images/client/scripts/sync_ferry_users.py
@@ -6,19 +6,21 @@ Adds FERRY users and identities to Rucio as account type USER.
 Also applies analysis account attributes/policy to these accounts.
 """
 
+import argparse
+from dataclasses import dataclass, asdict
 import logging
 import os
+import sys
 
 from rucio.client import Client
 from rucio.common.exception import AccountNotFound, Duplicate
 
 from FerryClient import FerryClient
 
-
 # setup logger
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
-ch = logging.StreamHandler()
+ch = logging.StreamHandler(stream=sys.stdout)
 ch.setLevel(logging.INFO)
 logger.addHandler(ch)
 
@@ -26,8 +28,7 @@ logger.addHandler(ch)
 ferry = FerryClient(logger=logger)
 client = Client()
 
-dry_run = True
-
+# analysis account attributes
 ANALYSIS_ATTRIBUTES = [
     "add_rule",
     "add_replicas",
@@ -37,8 +38,25 @@ ANALYSIS_ATTRIBUTES = [
 ]
 
 
-def main():
-    unitname = os.getenv("FERRY_VO", "int")
+@dataclass
+class User:
+    """
+    Dataclass that has values required to create
+    a Rucio Account
+    """
+    name: str
+    email: str
+    identities: list[str]
+    create: bool = False
+
+
+def sync_ferry_users(commit=False, delete_accounts=False, vo='int'):
+    """
+    Fetches users from FERRY and adds them to Rucio with analysis attributes
+    """
+    unitname = os.getenv("FERRY_VO", vo)
+    filtered_users = os.getenv("FILTER_USERS", None)
+
     try:
         members = ferry.getAffiliationMembers(unitname)[0]
     except Exception as e:
@@ -46,9 +64,16 @@ def main():
         logger.error(e)
         raise
 
+    # filter out specific users
+    if filtered_users:
+        filtered = filtered_users.split(',')
+        members['users'] = [m for m in members['users'] if m['username'] in filtered]
+
+    users_to_add = [] 
     for user in members['users']:
         username = user['username']
 
+        # ignore banned or deactivated users
         try:
             user = ferry.getUserInfo(username)
             if not user['status'] or user['banned']:
@@ -60,50 +85,102 @@ def main():
             userLdap = ferry.getUserLdapInfo(username)
             email = userLdap['mail']
         except Exception as e:
-            logger.error(f"Cannot get userLdapInfo for {username}")
+            logger.error(f"Could not get userLdapInfo for {username}")
             logger.error(e)
             continue
 
+        create = False
         try:
            client.get_account(username)
         except AccountNotFound:
-            logger.info(f"Account {username} not found. Adding...")
-            if not dry_run:
-                client.add_account(username, 'USER', email)
+            logger.info(f"Account {username} not found. Will create an account.")
+            create = True
 
-        if not dry_run:
-            logger.info(f"Adding scope for user: {username}")
-            try:
-                client.add_scope(username, f'user.{username}')
-            except Duplicate:
-                logger.info(f"Scope for user {username} already exists")
-
-        # add identities
-        logger.info(f"Adding identities for {username}")
+        # fetch identities
+        logger.info(f"Fetching identities for {username}")
         dn = ferry.getUserCertificateDNs(unitname, username)
-        if not dry_run:
-            for d in dn:
-                client.add_identity(username, d, "X509", email)
 
-        # add attributes
-        attributes = client.list_account_attributes(username)
-        logger.info(f"Adding analysis attributes")
-        for a in ANALYSIS_ATTRIBUTES:
-            if not dry_run:
-                try:
-                    client.add_account_attribute(username, a, "1")
-                except Duplicate as e:
-                    logger.error(e)
-                    continue
+        users_to_add.append(User(name=username, email=email, identities=dn, create=create))
+    
+    # Add or update users to Rucio
+    if commit:
+        for user in users_to_add:
+            add_user(user)
 
-    # delete rucio accounts not in FERRY members
+    # delete rucio accounts not in FERRY members or if their status has changed
+    if delete_accounts:
+        delete_users(members, commit)
+
+
+def add_user(user: User):
+    """
+    Add users to Rucio
+    """
+    username = user.name
+
+    # create user, if they do not exist
+    if user.create:
+        logger.info(f"Creating account for {username}")
+        client.add_account(username, 'USER', user.email)
+
+    # create a scope
+    logger.info(f"Adding scope for user: {username}")
+    try:
+        client.add_scope(username, f'user.{username}')
+    except Duplicate:
+        logger.info(f"Scope for user {username} already exists")
+
+    # add user identities
+    logger.info(f"Adding identities for {username}")
+    for d in user.identities:
+        try:
+            client.add_identity(username, d, "X509", user.email)
+        except Duplicate as e:
+            logger.info(e)
+            continue
+
+    # add attributes
+    logger.info(f"Adding analysis attributes")
+    for a in ANALYSIS_ATTRIBUTES:
+        try:
+            client.add_account_attribute(username, a, "1")
+        except Duplicate as e:
+            logger.error(e)
+            continue
+
+
+def delete_users(members, commit=False):
+    """
+    Checks and delete/disable users from Rucio
+    """
     rucio_accounts = client.list_accounts(account_type="USER")
     ferry_accounts = [m['username'] for m in members['users']]
     for a in rucio_accounts:
         if a['account'] not in ferry_accounts:
-            logger.info(f"Disabling account {a}")
-            if not dry_run:
+            logger.info(f"Disabling account {a}, account not affiliated")
+            if commit:
                 client.delete_account(a)
+        else:
+            index = ferry_accounts.index(a['account'])
+            user = members[index]
+            if not user['status'] or user['banned']:
+                logger.info(f"Disabling account {a}, FERRY disabled or banned")
+                if commit:
+                    client.delete_account(a)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Sync FERRY Users',
+        epilog='Syncs FERRY Users of a VO with Rucio')
+    parser.add_argument('--commit',
+                        action='store_true')
+    parser.add_argument('--delete_accounts',
+                        action='store_true')
+
+    args = parser.parse_args()
+
+    sync_ferry_users(commit=args.commit, delete_accounts=args.delete_accounts)
 
 
 if __name__ == "__main__":

--- a/overlays/dune-int/rucio/etc/ferry-sync-rucio.cfg
+++ b/overlays/dune-int/rucio/etc/ferry-sync-rucio.cfg
@@ -5,4 +5,5 @@ auth_host = https://dune-int-rucio.fnal.gov
 account = root
 ca_cert = /etc/grid-security/certificates
 auth_type = x509_proxy
+client_x509_proxy = /opt/proxy/x509up
 request_retries = 3

--- a/overlays/dune-int/rucio/etc/policy-package/__init__.py
+++ b/overlays/dune-int/rucio/etc/policy-package/__init__.py
@@ -1,7 +1,7 @@
 from .path_gen import construct_surl_dune_sam, construct_surl_dune_metacat
 from .lfn2pfn import lfn2pfn_DUNE
 
-SUPPORTED_VERSION=["32", "33"]
+SUPPORTED_VERSION=["32", "33", "34"]
 
 def get_algorithms():
     return { 'lfn2pfn': { 'DUNE': lfn2pfn_DUNE }, 'surl': { 'DUNE_sam': construct_surl_dune_sam,

--- a/overlays/dune-int/rucio/ferry-users.yaml
+++ b/overlays/dune-int/rucio/ferry-users.yaml
@@ -17,22 +17,20 @@ spec:
             - name: ca-volume
               mountPath: /out/
           volumes:
-          - name: ca-volume
-            emptyDir:
-              sizeLimit: 250Mi
-          - name: usercert
-            secret:
-              secretName: fnal-fts-cert
-          - name: userkey
-            secret:
-              secretName: fnal-fts-key
           - name: rucio-config
             secret:
               secretName: fnal-ferry-rucio-config
+          - name: proxy-volume
+            secret:
+              secretName: fnal-rucio-x509up
           containers:
             - name: sync-ferry-users
-              image: "imageregistry.fnal.gov/rucio-ams/rucio-ferry-sync:32.2.0"
+              image: "imageregistry.fnal.gov/rucio-ams/rucio-client:34.1.0.fnal"
               imagePullPolicy: Always
+              command:
+              - /bin/bash
+              - python3
+              - /scripts/sync_ferry_users.py
               resources:
                 limits:
                   cpu: 500m
@@ -41,12 +39,10 @@ spec:
                   cpu: 100m
                   memory: 128Mi
               volumeMounts:
-                - name: usercert
-                  mountPath: /opt/rucio/certs/
-                - name: userkey
-                  mountPath: /opt/rucio/keys/
                 - name: rucio-config
                   mountPath: /opt/rucio/etc
+                - name: proxy-volume
+                  mountPath: /opt/proxy
               env:
                 - name: RUCIO_URL
                   value: ""

--- a/overlays/dune-int/rucio/ferry-users.yaml
+++ b/overlays/dune-int/rucio/ferry-users.yaml
@@ -3,7 +3,8 @@ kind: CronJob
 metadata:
   name: fnal-sync-ferry-users
 spec:
-  schedule: "* * * * *"
+  schedule: "13 * * * *"
+  concurrencyPolicy: Forbid
   jobTemplate:
     spec:
       template:
@@ -11,10 +12,11 @@ spec:
           serviceAccountName: useroot
           initContainers:
           - name: grid-certs
-            image: docker.io/bjwhitefnal/grid-security-files:32
-            command: ["/bin/bash", "-c", "chmod 755 /out/ && cp -rv --preserve=links /grid-certificates/* /out/"]
+            image: ghcr.io/d-ylee/gridcert-container:v0.0.6
+              # image: docker.io/bjwhitefnal/grid-security-files:32
+            command: ["/bin/bash", "-c", "chmod 755 /out/ && cp -rv --preserve=links /etc/grid-security/certificates/* /out/"]
             volumeMounts:
-            - name: ca-volume
+            - name: ca-volume-grid
               mountPath: /out/
           volumes:
           - name: rucio-config
@@ -23,14 +25,22 @@ spec:
           - name: proxy-volume
             secret:
               secretName: fnal-rucio-x509up
+          - name: usercert
+            secret:
+              secretName: fnal-fts-cert
+          - name: userkey
+            secret:
+              secretName:  fnal-fts-key
+          - name: ca-volume-grid
+            emptyDir: {}
           containers:
             - name: sync-ferry-users
               image: "imageregistry.fnal.gov/rucio-ams/rucio-client:34.1.0.fnal"
               imagePullPolicy: Always
               command:
               - /bin/bash
-              - python3
-              - /scripts/sync_ferry_users.py
+              - -c
+              - python3 /scripts/sync_ferry_users.py --commit
               resources:
                 limits:
                   cpu: 500m
@@ -43,11 +53,25 @@ spec:
                   mountPath: /opt/rucio/etc
                 - name: proxy-volume
                   mountPath: /opt/proxy
+                - name: ca-volume-grid
+                  mountPath: /etc/grid-security/certificates
+                - name: usercert
+                  mountPath: /opt/rucio/certs/
+                - name: userkey
+                  mountPath: /opt/rucio/keys/
               env:
-                - name: RUCIO_URL
-                  value: ""
                 - name: FERRY_VO
                   value: "dune"
                 - name: FERRY_URL
                   value: "https://ferry.fnal.gov:8445"
+                - name: CA_PATH
+                  value: "/etc/grid-security/certificates"
+                - name: X509_USER_PROXY
+                  value: "/opt/proxy/x509up"
+                - name: X509_USER_CERT
+                  value: "/opt/rucio/certs/usercert.pem"
+                - name: X509_USER_KEY
+                  value: "/opt/rucio/keys/new_userkey.pem"
+                - name: FILTER_USERS
+                  value: "dylee,bjwhite,timm,apeisker"
           restartPolicy: OnFailure


### PR DESCRIPTION
Added a new client image for CronJob and other purposes.

The `dune-int` configuration for the CronJob uses an initContainer that uses the image built here: https://github.com/d-ylee/gridcert-container

This image is built using a GitHub action and is published in the GitHub registry. The ca-certs are installed using `osg-ca-certs`.