### PR TITLE
Enabled FERRY sync for rucio-dune

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,9 +181,23 @@ At Fermilab, we use centrally managed PostgreSQL databases.
 
 3. Follow instructions at <https://rucio.github.io/documentation/operator/database#upgrading-and-downgrading-the-database-schema>
 
+    > Ensure that in etc/alembic.ini the database connection string is is set to the same database connection string as the etc/rucio.cfg and issue the following command to verify the changes to the upgrade of the schema:
+    >
+    > ```bash
+    > alembic upgrade --sql $(alembic current | cut -d' '-f1):head
+    > ```
+    >
+    > You can edit and then apply the SQL directly on your database.
+    >
+    > ```bash
+    > alembic upgrade head
+    > ```
+
+    Rucio developers do no advise running upgrades using alembic
+
 4. Delete the pod with
 
     ```bash
     $ kubectl delete pod/rucio-db-upgrade
-    pod "rucio-db-upgrade" delted
+    pod "rucio-db-upgrade" deleted
     ```

--- a/images/client/scripts/FerryClient.py
+++ b/images/client/scripts/FerryClient.py
@@ -36,6 +36,7 @@ class FerryClient:
                 params=params,
                 cert=(self.cert, self.key),
                 verify=self.capath)
+            r.raise_for_status()
         except HTTPError as e:
             self.logger.error(e)
             raise

--- a/images/client/scripts/sync_ferry_users.py
+++ b/images/client/scripts/sync_ferry_users.py
@@ -4,6 +4,8 @@ Script to sync FERRY users to Rucio based on vo/afffiliation
 
 Adds FERRY users and identities to Rucio as account type USER.
 Also applies analysis account attributes/policy to these accounts.
+
+The DN of the cert used to access FERRY needs Read-only access
 """
 
 import argparse

--- a/overlays/dune/rucio/etc/ferry-sync-rucio.cfg
+++ b/overlays/dune/rucio/etc/ferry-sync-rucio.cfg
@@ -1,0 +1,9 @@
+[client]
+rucio_host = https://dune-rucio.fnal.gov
+auth_host = https://dune-rucio.fnal.gov
+
+account = root
+ca_cert = /etc/grid-security/certificates
+auth_type = x509_proxy
+client_x509_proxy = /opt/proxy/x509up
+request_retries = 3

--- a/overlays/dune/rucio/ferry-users.yaml
+++ b/overlays/dune/rucio/ferry-users.yaml
@@ -1,0 +1,75 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: fnal-sync-ferry-users
+spec:
+  schedule: "30 2 */1 * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: useroot
+          initContainers:
+          - name: grid-certs
+            image: ghcr.io/d-ylee/gridcert-container:v0.0.6
+              # image: docker.io/bjwhitefnal/grid-security-files:32
+            command: ["/bin/bash", "-c", "chmod 755 /out/ && cp -rv --preserve=links /etc/grid-security/certificates/* /out/"]
+            volumeMounts:
+            - name: ca-volume-grid
+              mountPath: /out/
+          volumes:
+          - name: rucio-config
+            secret:
+              secretName: fnal-ferry-rucio-config
+          - name: proxy-volume
+            secret:
+              secretName: fnal-rucio-x509up
+          - name: usercert
+            secret:
+              secretName: fnal-fts-cert
+          - name: userkey
+            secret:
+              secretName:  fnal-fts-key
+          - name: ca-volume-grid
+            emptyDir: {}
+          containers:
+            - name: sync-ferry-users
+              image: "imageregistry.fnal.gov/rucio-ams/rucio-client:34.3.0.fnal"
+              imagePullPolicy: Always
+              command:
+              - /bin/bash
+              - -c
+              - python3 /scripts/sync_ferry_users.py --commit
+              resources:
+                limits:
+                  cpu: 500m
+                  memory: 256Mi
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+              volumeMounts:
+                - name: rucio-config
+                  mountPath: /opt/rucio/etc
+                - name: proxy-volume
+                  mountPath: /opt/proxy
+                - name: ca-volume-grid
+                  mountPath: /etc/grid-security/certificates
+                - name: usercert
+                  mountPath: /opt/rucio/certs/
+                - name: userkey
+                  mountPath: /opt/rucio/keys/
+              env:
+                - name: FERRY_VO
+                  value: "dune"
+                - name: FERRY_URL
+                  value: "https://ferry.fnal.gov:8445"
+                - name: CA_PATH
+                  value: "/etc/grid-security/certificates"
+                - name: X509_USER_PROXY
+                  value: "/opt/proxy/x509up"
+                - name: X509_USER_CERT
+                  value: "/opt/rucio/certs/usercert.pem"
+                - name: X509_USER_KEY
+                  value: "/opt/rucio/keys/new_userkey.pem"
+          restartPolicy: OnFailure

--- a/overlays/dune/rucio/kustomization.yaml
+++ b/overlays/dune/rucio/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 - cache.yaml
 - prometheus.yaml
 - messenger.yaml
+- ferry-users.yaml
 
 patchesStrategicMerge:
 - patch-service.yaml
@@ -135,3 +136,8 @@ secretGenerator:
 - name: fnal-httpd-custom-config
   files:
   - fnal-custom-config.conf=etc/fnal-custom-config.conf
+
+# Rucio/FERRY Syncer Rucio config
+- name: fnal-ferry-rucio-config
+  files:
+  - rucio.cfg=etc/ferry-sync-rucio.cfg

--- a/scripts/download-secret.sh
+++ b/scripts/download-secret.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# Script to download a secret from a kuberentes cluster
+#
+# usage: ./download-secret.sh <secret name> <dir-to-save>
+
+secret_name=$1
+
+directory_to_save=${3-$2}
+
+mkdir -p $directory_to_save
+
+values=$(kubectl get secrets $secret_name -o json \
+    | jq -r '.data | keys[] as $k | "\($k):\(.[$k])"')
+for file_content in $values
+do
+    file_name=$(echo $file_content | cut -d':' -f1)
+    echo $file_content | cut -d':' -f2 | base64 --decode > $directory_to_save/$file_name
+    echo "Created $directory_to_save/$file_name"
+done


### PR DESCRIPTION
Added a note in sync_ferry_users.py to remember to setup read-only access to FERRY
Updated README.md for database upgrading
Have FerryClient raise an exception if an HTTPError occured (4XX code)